### PR TITLE
Apple OIDC 로그인 기능 추가

### DIFF
--- a/src/main/java/makeus/cmc/malmo/adaptor/in/web/controller/LoginController.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/in/web/controller/LoginController.java
@@ -26,7 +26,7 @@ public class LoginController {
     )
     @ApiCommonResponses.Login
     @PostMapping("/login/kakao")
-    public BaseResponse<SignInUseCase.SignInResponse> login(@RequestBody LoginRequestDto requestDto) {
+    public BaseResponse<SignInUseCase.SignInResponse> loginWithKakao(@RequestBody KakaoLoginRequestDto requestDto) {
         SignInUseCase.SignInKakaoCommand command = SignInUseCase.SignInKakaoCommand.builder()
                 .idToken(requestDto.idToken)
                 .accessToken(requestDto.accessToken)
@@ -34,9 +34,28 @@ public class LoginController {
         return BaseResponse.success(signInUseCase.signInKakao(command));
     }
 
+    @Operation(
+            summary = "애플 소셜 로그인",
+            description = "애플 OIDC ID 토큰을 통해 로그인합니다. 신규 사용자의 경우 자동으로 회원가입이 진행됩니다."
+    )
+    @ApiCommonResponses.Login
+    @PostMapping("/login/apple")
+    public BaseResponse<SignInUseCase.SignInResponse> loginWithApple(@RequestBody AppleLoginRequestDto requestDto) {
+        SignInUseCase.SignInAppleCommand command = SignInUseCase.SignInAppleCommand.builder()
+                .idToken(requestDto.idToken)
+                .build();
+        return BaseResponse.success(signInUseCase.signInApple(command));
+    }
+
+
     @Data
-    public static class LoginRequestDto {
+    public static class KakaoLoginRequestDto {
         private String idToken;
         private String accessToken;
+    }
+
+    @Data
+    public static class AppleLoginRequestDto {
+        private String idToken;
     }
 }

--- a/src/main/java/makeus/cmc/malmo/adaptor/out/oidc/AbstractOidcAdapter.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/out/oidc/AbstractOidcAdapter.java
@@ -1,0 +1,55 @@
+package makeus.cmc.malmo.adaptor.out.oidc;
+
+import com.auth0.jwk.Jwk;
+import com.auth0.jwk.JwkProvider;
+import com.auth0.jwk.JwkProviderBuilder;
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.interfaces.DecodedJWT;
+import makeus.cmc.malmo.adaptor.out.oidc.exception.OidcIdTokenException;
+
+import java.net.URL;
+import java.security.interfaces.RSAPublicKey;
+import java.util.concurrent.TimeUnit;
+
+public abstract class AbstractOidcAdapter {
+
+    protected final String iss; // 발급자
+    protected final String aud; // 앱 클라이언트 ID
+    protected final JwkProvider provider;
+
+    protected AbstractOidcAdapter(String iss, String aud, String jwksUri) throws Exception {
+        this.iss = iss;
+        this.aud = aud;
+        this.provider = new JwkProviderBuilder(new URL(jwksUri))
+                .cached(10, 60, TimeUnit.MINUTES)
+                .rateLimited(10, 1, TimeUnit.MINUTES)
+                .build();
+    }
+
+    public String validateToken(String idToken) {
+        try {
+            DecodedJWT jwt = JWT.decode(idToken);
+
+            // 1. 서명 검증
+            Jwk jwk = provider.get(jwt.getKeyId());
+            Algorithm algorithm = Algorithm.RSA256((RSAPublicKey) jwk.getPublicKey(), null);
+            algorithm.verify(jwt);
+
+            // 2. 발급자(iss), 대상(aud), 만료 시간(exp) 검증
+            if (!jwt.getIssuer().equals(iss) || !jwt.getAudience().contains(aud)) {
+                throw new OidcIdTokenException("Invalid OIDC Token");
+            }
+
+            if (jwt.getExpiresAt().before(new java.util.Date())) {
+                throw new OidcIdTokenException("Expired OIDC Token");
+            }
+
+            // 3. 검증 성공 시 Provider Id 반환
+            return jwt.getSubject();
+
+        } catch (Exception e) {
+            throw new OidcIdTokenException("Failed to validate OIDC Token", e);
+        }
+    }
+}

--- a/src/main/java/makeus/cmc/malmo/adaptor/out/oidc/AppleOidcAdapter.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/out/oidc/AppleOidcAdapter.java
@@ -1,0 +1,29 @@
+package makeus.cmc.malmo.adaptor.out.oidc;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.interfaces.DecodedJWT;
+import makeus.cmc.malmo.adaptor.out.oidc.exception.OidcIdTokenException;
+import makeus.cmc.malmo.application.port.out.AppleIdTokenPort;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AppleOidcAdapter extends AbstractOidcAdapter implements AppleIdTokenPort {
+
+    public AppleOidcAdapter(
+            @Value("${apple.oidc.iss}") String iss,
+            @Value("${apple.oidc.aud}") String aud,
+            @Value("${apple.oidc.jwks-uri}") String jwksUri) throws Exception {
+        super(iss, aud, jwksUri);
+    }
+
+    public String extractEmailFromIdToken(String idToken) {
+        try {
+            DecodedJWT jwt = JWT.decode(idToken);
+            return jwt.getClaim("email").asString();
+        } catch (Exception e) {
+            throw new OidcIdTokenException("Failed to extract email from Apple ID token", e);
+        }
+    }
+
+}

--- a/src/main/java/makeus/cmc/malmo/adaptor/out/oidc/KakaoOidcAdapter.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/out/oidc/KakaoOidcAdapter.java
@@ -1,63 +1,16 @@
 package makeus.cmc.malmo.adaptor.out.oidc;
 
-import com.auth0.jwk.Jwk;
-import com.auth0.jwk.JwkProvider;
-import com.auth0.jwk.JwkProviderBuilder;
-import com.auth0.jwt.JWT;
-import com.auth0.jwt.algorithms.Algorithm;
-import com.auth0.jwt.interfaces.DecodedJWT;
-import makeus.cmc.malmo.adaptor.out.oidc.exception.OidcIdTokenException;
-import makeus.cmc.malmo.application.port.out.ValidateOidcTokenPort;
+import makeus.cmc.malmo.application.port.out.kakaoIdTokenPort;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
-import java.net.URL;
-import java.security.interfaces.RSAPublicKey;
-import java.util.concurrent.TimeUnit;
-
 @Component
-public class KakaoOidcAdapter implements ValidateOidcTokenPort {
-
-    private final String iss; // 발급자
-    private final String aud; // 앱 클라이언트 ID
-    private final JwkProvider provider;
+public class KakaoOidcAdapter extends AbstractOidcAdapter implements kakaoIdTokenPort {
 
     public KakaoOidcAdapter(
             @Value("${kakao.oidc.iss}") String iss,
             @Value("${kakao.oidc.aud}") String aud,
             @Value("${kakao.oidc.jwks-uri}") String jwksUri) throws Exception {
-        this.iss = iss;
-        this.aud = aud;
-        this.provider = new JwkProviderBuilder(new URL(jwksUri))
-                .cached(10, 60, TimeUnit.MINUTES)
-                .rateLimited(10, 1, TimeUnit.MINUTES)
-                .build();
-    }
-
-    @Override
-    public String validateKakao(String idToken) {
-        try {
-            DecodedJWT jwt = JWT.decode(idToken);
-
-            // 1. 서명 검증
-            Jwk jwk = provider.get(jwt.getKeyId());
-            Algorithm algorithm = Algorithm.RSA256((RSAPublicKey) jwk.getPublicKey(), null);
-            algorithm.verify(jwt);
-
-            // 2. 발급자(iss), 대상(aud), 만료 시간(exp) 검증
-            if (!jwt.getIssuer().equals(iss) || !jwt.getAudience().contains(aud)) {
-                throw new OidcIdTokenException("Invalid OIDC Token");
-            }
-
-            if (jwt.getExpiresAt().before(new java.util.Date())) {
-                throw new OidcIdTokenException("Expired OIDC Token");
-            }
-
-            // 3. 검증 성공 시 Provider Id 반환
-            return jwt.getSubject();
-
-        } catch (Exception e) {
-            throw new OidcIdTokenException("Failed to validate OIDC Token", e);
-        }
+        super(iss, aud, jwksUri);
     }
 }

--- a/src/main/java/makeus/cmc/malmo/application/port/in/SignInUseCase.java
+++ b/src/main/java/makeus/cmc/malmo/application/port/in/SignInUseCase.java
@@ -6,12 +6,19 @@ import lombok.Data;
 public interface SignInUseCase {
 
     SignInResponse signInKakao(SignInKakaoCommand command);
+    SignInResponse signInApple(SignInAppleCommand command);
 
     @Data
     @Builder
     class SignInKakaoCommand {
         private String idToken;
         private String accessToken;
+    }
+
+    @Data
+    @Builder
+    class SignInAppleCommand {
+        private String idToken;
     }
 
     @Data

--- a/src/main/java/makeus/cmc/malmo/application/port/out/AppleIdTokenPort.java
+++ b/src/main/java/makeus/cmc/malmo/application/port/out/AppleIdTokenPort.java
@@ -1,0 +1,7 @@
+package makeus.cmc.malmo.application.port.out;
+
+public interface AppleIdTokenPort {
+    // OIDC 토큰을 검증하고 사용자의 providerId를 반환
+    String validateToken(String idToken);
+    String extractEmailFromIdToken(String idToken);
+}

--- a/src/main/java/makeus/cmc/malmo/application/port/out/kakaoIdTokenPort.java
+++ b/src/main/java/makeus/cmc/malmo/application/port/out/kakaoIdTokenPort.java
@@ -1,6 +1,6 @@
 package makeus.cmc.malmo.application.port.out;
 
-public interface ValidateOidcTokenPort {
+public interface kakaoIdTokenPort {
     // OIDC 토큰을 검증하고 사용자의 providerId를 반환
-    String validateKakao(String idToken);
+    String validateToken(String idToken);
 }

--- a/src/main/java/makeus/cmc/malmo/application/service/SignInService.java
+++ b/src/main/java/makeus/cmc/malmo/application/service/SignInService.java
@@ -63,6 +63,7 @@ public class SignInService implements SignInUseCase {
     }
 
     @Override
+    @Transactional
     public SignInResponse signInApple(SignInAppleCommand command) {
         // 1. OIDC ID 토큰 검증
         String providerId = appleIdTokenPort.validateToken(command.getIdToken());

--- a/src/main/java/makeus/cmc/malmo/domain/model/member/Member.java
+++ b/src/main/java/makeus/cmc/malmo/domain/model/member/Member.java
@@ -24,15 +24,13 @@ public class Member extends BaseTimeEntity {
     private String nickname;
     private String email;
     
-    public static Member createMember(Provider provider, String providerId, MemberRole memberRole, MemberState memberState, String email, LoveType loveType) {
+    public static Member createMember(Provider provider, String providerId, MemberRole memberRole, MemberState memberState, String email) {
         return Member.builder()
                 .provider(provider)
                 .providerId(providerId)
                 .memberRole(memberRole)
                 .memberState(memberState)
                 .email(email)
-                .loveType(loveType)
-                .isAlarmOn(true)
                 .build();
     }
 

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -21,3 +21,9 @@ kakao:
     aud: ${KAKAO_REST_API_KEY}
     jwks-uri: https://kauth.kakao.com/.well-known/jwks.json
     user-info-uri: https://kapi.kakao.com/v1/oidc/userinfo
+
+apple:
+  oidc:
+    iss: https://appleid.apple.com
+    aud: ${APPLE_REST_API_KEY}
+    jwks-uri: https://appleid.apple.com/auth/keys


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> - #1 

## 📝 작업 내용

> Apple OIDC ID Token을 통한 사용자 검증 및 회원 저장 로직 추가

Kakao와 ID Token 검증 과정 중복으로 추상 클래스를 상속하도록 변경
