### PR TITLE
초대코드 상태 및 커플 전용 API 검증을 위한 로직 추가

### DIFF
--- a/src/main/java/makeus/cmc/malmo/adaptor/in/aop/CheckCoupleMember.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/in/aop/CheckCoupleMember.java
@@ -1,0 +1,11 @@
+package makeus.cmc.malmo.adaptor.in.aop;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CheckCoupleMember {
+}

--- a/src/main/java/makeus/cmc/malmo/adaptor/in/aop/CoupleMemberValidationAspect.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/in/aop/CoupleMemberValidationAspect.java
@@ -1,0 +1,33 @@
+package makeus.cmc.malmo.adaptor.in.aop;
+
+import lombok.RequiredArgsConstructor;
+import makeus.cmc.malmo.domain.model.value.MemberId;
+import makeus.cmc.malmo.domain.service.MemberDomainValidationService;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class CoupleMemberValidationAspect {
+
+    private final MemberDomainValidationService mmemberValidationService;
+
+    @Before("@annotation(CheckCoupleMember)")
+    public void checkCoupleMember() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication == null || !(authentication.getPrincipal() instanceof User user)) {
+            throw new AuthenticationCredentialsNotFoundException("인증된 사용자를 찾을 수 없습니다.");
+        }
+
+        Long memberId = Long.valueOf(user.getUsername());
+        mmemberValidationService.isMemberCouple(MemberId.of(memberId));
+    }
+}
+

--- a/src/main/java/makeus/cmc/malmo/adaptor/in/exception/ErrorCode.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/in/exception/ErrorCode.java
@@ -15,6 +15,7 @@ public enum ErrorCode {
     NO_SUCH_TERMS(HttpStatus.BAD_REQUEST, 40003, "약관이 존재하지 않습니다."),
     NO_SUCH_LOVE_TYPE(HttpStatus.BAD_REQUEST, 40004, "애착 유형이 존재하지 않습니다."),
     NO_SUCH_LOVE_TYPE_QUESTION(HttpStatus.BAD_REQUEST, 40005, "애착 유형 질문이 존재하지 않습니다."),
+    USED_COUPLE_CODE(HttpStatus.BAD_REQUEST, 40006, "이미 사용된 초대 코드입니다."),
 
     // 401 Unauthorized
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, 40100, "인증되지 않은 사용자입니다."),

--- a/src/main/java/makeus/cmc/malmo/adaptor/in/exception/ErrorCode.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/in/exception/ErrorCode.java
@@ -1,4 +1,4 @@
-package makeus.cmc.malmo.adaptor.in.web.exception;
+package makeus.cmc.malmo.adaptor.in.exception;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -23,6 +23,7 @@ public enum ErrorCode {
 
     // 403 Forbidden
     FORBIDDEN(HttpStatus.FORBIDDEN, 40300, "접근 권한이 없습니다."),
+    NOT_COUPLE_MEMBER(HttpStatus.FORBIDDEN, 40301, "커플 등록 전인 사용자입니다. 커플 등록 후 이용해주세요."),
 
     // 404 Not Found
     NOT_FOUND(HttpStatus.NOT_FOUND, 40400, "요청한 리소스를 찾을 수 없습니다."),

--- a/src/main/java/makeus/cmc/malmo/adaptor/in/exception/ErrorResponse.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/in/exception/ErrorResponse.java
@@ -1,4 +1,4 @@
-package makeus.cmc.malmo.adaptor.in.web.exception;
+package makeus.cmc.malmo.adaptor.in.exception;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AccessLevel;

--- a/src/main/java/makeus/cmc/malmo/adaptor/in/exception/GlobalExceptionHandler.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/in/exception/GlobalExceptionHandler.java
@@ -79,6 +79,12 @@ public class GlobalExceptionHandler {
         return ErrorResponse.of(ErrorCode.NOT_COUPLE_MEMBER);
     }
 
+    @ExceptionHandler({UsedCoupleCodeException.class})
+    public ResponseEntity<ErrorResponse> handleUsedCoupleCodeException(UsedCoupleCodeException e) {
+        log.error("[GlobalExceptionHandler: handleUsedCoupleCodeException 호출]", e);
+        return ErrorResponse.of(ErrorCode.USED_COUPLE_CODE);
+    }
+
 
 
 

--- a/src/main/java/makeus/cmc/malmo/adaptor/in/exception/GlobalExceptionHandler.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/in/exception/GlobalExceptionHandler.java
@@ -1,4 +1,4 @@
-package makeus.cmc.malmo.adaptor.in.web.exception;
+package makeus.cmc.malmo.adaptor.in.exception;
 
 import lombok.extern.slf4j.Slf4j;
 import makeus.cmc.malmo.adaptor.out.oidc.exception.OidcIdTokenException;
@@ -71,6 +71,12 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse> handleLoveTypeQuestionNotFoundException(LoveTypeQuestionNotFoundException e) {
         log.error("[GlobalExceptionHandler: handleLoveTypeQuestionNotFoundException 호출]", e);
         return ErrorResponse.of(ErrorCode.NO_SUCH_LOVE_TYPE_QUESTION);
+    }
+
+    @ExceptionHandler({NotCoupleMemberException.class})
+    public ResponseEntity<ErrorResponse> handleNotCoupleMemberException(NotCoupleMemberException e) {
+        log.error("[GlobalExceptionHandler: handleNotCoupleMemberException 호출]", e);
+        return ErrorResponse.of(ErrorCode.NOT_COUPLE_MEMBER);
     }
 
 

--- a/src/main/java/makeus/cmc/malmo/adaptor/in/exception/NotCoupleMemberException.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/in/exception/NotCoupleMemberException.java
@@ -1,0 +1,7 @@
+package makeus.cmc.malmo.adaptor.in.exception;
+
+public class NotCoupleMemberException extends RuntimeException {
+    public NotCoupleMemberException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/makeus/cmc/malmo/adaptor/in/web/controller/CoupleController.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/in/web/controller/CoupleController.java
@@ -39,6 +39,7 @@ public class CoupleController {
             content = @Content(schema = @Schema(implementation = SwaggerResponses.CoupleLinkSuccessResponse.class))
     )
     @ApiCommonResponses.RequireAuth
+    @ApiCommonResponses.CoupleCode
     @PostMapping
     public BaseResponse<CoupleLinkUseCase.CoupleLinkResponse> linkCouple(
             @AuthenticationPrincipal User user,

--- a/src/main/java/makeus/cmc/malmo/adaptor/in/web/controller/SignUpController.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/in/web/controller/SignUpController.java
@@ -42,7 +42,7 @@ public class SignUpController {
     )
     @ApiCommonResponses.RequireAuth
     @ApiCommonResponses.SignUp
-    @PostMapping("/sign-up")
+    @PostMapping("/members/onboarding")
     public BaseResponse<SignUpUseCase.SignUpResponse> signUp(
             @AuthenticationPrincipal User user,
             @Valid @RequestBody SignUpRequestDto requestDto

--- a/src/main/java/makeus/cmc/malmo/adaptor/in/web/docs/ApiCommonResponses.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/in/web/docs/ApiCommonResponses.java
@@ -127,8 +127,8 @@ public class ApiCommonResponses {
     @Retention(RetentionPolicy.RUNTIME)
     @ApiResponses(value = {
             @ApiResponse(
-                    responseCode = "400",
-                    description = "커플로 등록되지 않은 사용자입니다.",
+                    responseCode = "403",
+                    description = "커플 등록 전인 사용자입니다. 커플 등록 후 이용해주세요.",
                     content = @Content(schema = @Schema(implementation = SwaggerErrorResponse.class))
             )
     })

--- a/src/main/java/makeus/cmc/malmo/adaptor/in/web/docs/ApiCommonResponses.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/in/web/docs/ApiCommonResponses.java
@@ -134,4 +134,16 @@ public class ApiCommonResponses {
     })
     public @interface OnlyCouple {
     }
+
+    @Target({ElementType.METHOD})
+    @Retention(RetentionPolicy.RUNTIME)
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "이미 사용된 초대 코드입니다.",
+                    content = @Content(schema = @Schema(implementation = SwaggerErrorResponse.class))
+            )
+    })
+    public @interface CoupleCode {
+    }
 }

--- a/src/main/java/makeus/cmc/malmo/adaptor/in/web/security/CustomAccessDeniedHandler.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/in/web/security/CustomAccessDeniedHandler.java
@@ -5,7 +5,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import makeus.cmc.malmo.adaptor.in.web.exception.ErrorCode;
+import makeus.cmc.malmo.adaptor.in.exception.ErrorCode;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.access.AccessDeniedException;

--- a/src/main/java/makeus/cmc/malmo/adaptor/in/web/security/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/in/web/security/CustomAuthenticationEntryPoint.java
@@ -5,7 +5,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import makeus.cmc.malmo.adaptor.in.web.exception.ErrorCode;
+import makeus.cmc.malmo.adaptor.in.exception.ErrorCode;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.AuthenticationException;

--- a/src/main/java/makeus/cmc/malmo/adaptor/in/web/security/SecurityErrorResponseDto.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/in/web/security/SecurityErrorResponseDto.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import makeus.cmc.malmo.adaptor.in.web.exception.ErrorCode;
+import makeus.cmc.malmo.adaptor.in.exception.ErrorCode;
 import org.slf4j.MDC;
 
 @Getter

--- a/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/ValidateMemberAdapter.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/ValidateMemberAdapter.java
@@ -1,0 +1,19 @@
+package makeus.cmc.malmo.adaptor.out.persistence;
+
+import lombok.RequiredArgsConstructor;
+import makeus.cmc.malmo.adaptor.out.persistence.repository.MemberRepository;
+import makeus.cmc.malmo.application.port.out.ValidateMemberPort;
+import makeus.cmc.malmo.domain.model.value.MemberId;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ValidateMemberAdapter implements ValidateMemberPort {
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    public boolean isCoupleMember(MemberId memberId) {
+        return memberRepository.isCoupleMember(memberId.getValue());
+    }
+}

--- a/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/entity/couple/CoupleCodeEntity.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/entity/couple/CoupleCodeEntity.java
@@ -25,6 +25,9 @@ public class CoupleCodeEntity extends BaseTimeEntityJpa {
 
     private LocalDate startLoveDate;
 
+    @Enumerated(EnumType.STRING)
+    private CoupleCodeStateJpa coupleCodeStateJpa;
+
     @AttributeOverride(name = "id", column = @Column(name = "member_id", nullable = false))
     @Embedded
     private MemberEntityId memberEntityId;

--- a/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/entity/couple/CoupleCodeStateJpa.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/entity/couple/CoupleCodeStateJpa.java
@@ -1,0 +1,5 @@
+package makeus.cmc.malmo.adaptor.out.persistence.entity.couple;
+
+public enum CoupleCodeStateJpa {
+    ALIVE, USED, DELETED;
+}

--- a/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/mapper/CoupleCodeMapper.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/mapper/CoupleCodeMapper.java
@@ -1,8 +1,10 @@
 package makeus.cmc.malmo.adaptor.out.persistence.mapper;
 
 import makeus.cmc.malmo.adaptor.out.persistence.entity.couple.CoupleCodeEntity;
+import makeus.cmc.malmo.adaptor.out.persistence.entity.couple.CoupleCodeStateJpa;
 import makeus.cmc.malmo.adaptor.out.persistence.entity.value.MemberEntityId;
 import makeus.cmc.malmo.domain.model.member.CoupleCode;
+import makeus.cmc.malmo.domain.model.member.CoupleCodeState;
 import makeus.cmc.malmo.domain.model.value.MemberId;
 import org.springframework.stereotype.Component;
 
@@ -14,6 +16,7 @@ public class CoupleCodeMapper {
                 .inviteCode(entity.getInviteCode())
                 .startLoveDate(entity.getStartLoveDate())
                 .memberId(MemberId.of(entity.getMemberEntityId().getValue()))
+                .coupleCodeState(toCoupleCodeState(entity.getCoupleCodeStateJpa()))
                 .createdAt(entity.getCreatedAt())
                 .modifiedAt(entity.getModifiedAt())
                 .deletedAt(entity.getDeletedAt())
@@ -26,9 +29,18 @@ public class CoupleCodeMapper {
                 .inviteCode(domain.getInviteCode())
                 .startLoveDate(domain.getStartLoveDate())
                 .memberEntityId(MemberEntityId.of(domain.getMemberId().getValue()))
+                .coupleCodeStateJpa(toCoupleCodeStateJpa(domain.getCoupleCodeState()))
                 .createdAt(domain.getCreatedAt())
                 .modifiedAt(domain.getModifiedAt())
                 .deletedAt(domain.getDeletedAt())
                 .build();
+    }
+
+    public CoupleCodeState toCoupleCodeState(CoupleCodeStateJpa coupleCodeStateJpa) {
+        return coupleCodeStateJpa != null ? CoupleCodeState.valueOf(coupleCodeStateJpa.name()) : null;
+    }
+
+    public CoupleCodeStateJpa toCoupleCodeStateJpa(CoupleCodeState coupleCodeState) {
+        return coupleCodeState != null ? CoupleCodeStateJpa.valueOf(coupleCodeState.name()) : null;
     }
 }

--- a/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/repository/custom/MemberRepositoryCustom.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/repository/custom/MemberRepositoryCustom.java
@@ -8,4 +8,6 @@ import java.util.Optional;
 public interface MemberRepositoryCustom {
     Optional<LoadMemberPort.MemberResponseRepositoryDto> findMemberDetailsById(Long memberId);
     Optional<LoadPartnerPort.PartnerMemberRepositoryDto> findPartnerMember(Long memberId);
+
+    boolean isCoupleMember(Long memberId);
 }

--- a/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/repository/custom/MemberRepositoryCustomImpl.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/repository/custom/MemberRepositoryCustomImpl.java
@@ -3,6 +3,7 @@ package makeus.cmc.malmo.adaptor.out.persistence.repository.custom;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
+import makeus.cmc.malmo.adaptor.out.persistence.entity.couple.CoupleMemberStateJpa;
 import makeus.cmc.malmo.application.port.out.LoadMemberPort;
 import makeus.cmc.malmo.application.port.out.LoadPartnerPort;
 
@@ -62,5 +63,15 @@ public class MemberRepositoryCustomImpl implements MemberRepositoryCustom{
                 )
                 .fetchOne();
         return Optional.ofNullable(dto);
+    }
+
+    @Override
+    public boolean isCoupleMember(Long memberId) {
+        return queryFactory
+                .selectOne()
+                .from(coupleMemberEntity)
+                .where(coupleMemberEntity.memberEntityId.value.eq(memberId)
+                        .and(coupleMemberEntity.coupleMemberStateJpa.eq(CoupleMemberStateJpa.ALIVE)))
+                .fetchFirst() != null;
     }
 }

--- a/src/main/java/makeus/cmc/malmo/application/port/out/ValidateMemberPort.java
+++ b/src/main/java/makeus/cmc/malmo/application/port/out/ValidateMemberPort.java
@@ -1,0 +1,7 @@
+package makeus.cmc.malmo.application.port.out;
+
+import makeus.cmc.malmo.domain.model.value.MemberId;
+
+public interface ValidateMemberPort {
+    boolean isCoupleMember(MemberId memberId);
+}

--- a/src/main/java/makeus/cmc/malmo/application/service/CoupleService.java
+++ b/src/main/java/makeus/cmc/malmo/application/service/CoupleService.java
@@ -30,7 +30,7 @@ public class CoupleService implements CoupleLinkUseCase {
         Member member = memberDomainService.getMemberById(MemberId.of(command.getUserId()));
         CoupleCode coupleCode = coupleCodeDomainService.getCoupleCodeByInviteCode(command.getCoupleCode());
 
-        Couple couple = coupleDomainService.createCouple(member, coupleCode);
+        Couple couple = coupleDomainService.createCoupleByCoupleCode(member, coupleCode);
 
         Couple savedCouple = saveCouplePort.saveCouple(couple);
 

--- a/src/main/java/makeus/cmc/malmo/application/service/MemberInfoService.java
+++ b/src/main/java/makeus/cmc/malmo/application/service/MemberInfoService.java
@@ -1,12 +1,14 @@
 package makeus.cmc.malmo.application.service;
 
 import lombok.RequiredArgsConstructor;
+import makeus.cmc.malmo.adaptor.in.aop.CheckCoupleMember;
 import makeus.cmc.malmo.domain.exception.MemberNotFoundException;
 import makeus.cmc.malmo.application.port.in.GetMemberUseCase;
 import makeus.cmc.malmo.application.port.in.GetPartnerUseCase;
 import makeus.cmc.malmo.application.port.out.LoadMemberPort;
 import makeus.cmc.malmo.application.port.out.LoadPartnerPort;
 import makeus.cmc.malmo.domain.model.member.MemberState;
+import org.hibernate.annotations.Check;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -36,6 +38,7 @@ public class MemberInfoService implements GetMemberUseCase, GetPartnerUseCase {
     }
 
     @Override
+    @CheckCoupleMember
     public PartnerMemberResponseDto getMemberInfo(PartnerInfoCommand command) {
         LoadPartnerPort.PartnerMemberRepositoryDto partner = loadPartnerPort.loadPartnerByMemberId(command.getUserId())
                 .orElseThrow(MemberNotFoundException::new);

--- a/src/main/java/makeus/cmc/malmo/domain/exception/UsedCoupleCodeException.java
+++ b/src/main/java/makeus/cmc/malmo/domain/exception/UsedCoupleCodeException.java
@@ -1,0 +1,7 @@
+package makeus.cmc.malmo.domain.exception;
+
+public class UsedCoupleCodeException extends RuntimeException {
+    public UsedCoupleCodeException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/makeus/cmc/malmo/domain/model/member/CoupleCode.java
+++ b/src/main/java/makeus/cmc/malmo/domain/model/member/CoupleCode.java
@@ -21,4 +21,8 @@ public class CoupleCode extends BaseTimeEntity {
     public boolean isUsed() {
         return coupleCodeState == CoupleCodeState.USED;
     }
+
+    public void expire() {
+        this.coupleCodeState = CoupleCodeState.USED;
+    }
 }

--- a/src/main/java/makeus/cmc/malmo/domain/model/member/CoupleCode.java
+++ b/src/main/java/makeus/cmc/malmo/domain/model/member/CoupleCode.java
@@ -16,4 +16,9 @@ public class CoupleCode extends BaseTimeEntity {
     private String inviteCode;
     private LocalDate startLoveDate;
     private MemberId memberId;
+    private CoupleCodeState coupleCodeState;
+
+    public boolean isUsed() {
+        return coupleCodeState == CoupleCodeState.USED;
+    }
 }

--- a/src/main/java/makeus/cmc/malmo/domain/model/member/CoupleCodeState.java
+++ b/src/main/java/makeus/cmc/malmo/domain/model/member/CoupleCodeState.java
@@ -1,0 +1,5 @@
+package makeus.cmc.malmo.domain.model.member;
+
+public enum CoupleCodeState {
+    ALIVE, USED, DELETED;
+}

--- a/src/main/java/makeus/cmc/malmo/domain/model/member/Member.java
+++ b/src/main/java/makeus/cmc/malmo/domain/model/member/Member.java
@@ -62,6 +62,7 @@ public class Member extends BaseTimeEntity {
                 .inviteCode(inviteCode)
                 .startLoveDate(startLoveDate)
                 .memberId(MemberId.of(this.id))
+                .coupleCodeState(CoupleCodeState.ALIVE)
                 .build();
     }
 }

--- a/src/main/java/makeus/cmc/malmo/domain/service/CoupleCodeDomainService.java
+++ b/src/main/java/makeus/cmc/malmo/domain/service/CoupleCodeDomainService.java
@@ -6,6 +6,7 @@ import makeus.cmc.malmo.domain.exception.InviteCodeGenerateFailedException;
 import makeus.cmc.malmo.application.port.out.GenerateInviteCodePort;
 import makeus.cmc.malmo.application.port.out.LoadCoupleCodePort;
 import makeus.cmc.malmo.application.port.out.SaveCoupleCodePort;
+import makeus.cmc.malmo.domain.exception.UsedCoupleCodeException;
 import makeus.cmc.malmo.domain.model.member.CoupleCode;
 import makeus.cmc.malmo.domain.model.member.Member;
 import makeus.cmc.malmo.domain.model.value.MemberId;
@@ -27,8 +28,14 @@ public class CoupleCodeDomainService {
     private static final int MAX_RETRY = 10;
 
     public CoupleCode getCoupleCodeByInviteCode(String inviteCode) {
-        return loadCoupleCodePort.loadCoupleCodeByInviteCode(inviteCode)
+        CoupleCode coupleCode = loadCoupleCodePort.loadCoupleCodeByInviteCode(inviteCode)
                 .orElseThrow(CoupleCodeNotFoundException::new);
+
+        if (coupleCode.isUsed()) {
+            throw new UsedCoupleCodeException("이미 사용된 커플 코드입니다.");
+        }
+
+        return coupleCode;
     }
 
     public CoupleCode getCoupleCodeByMemberId(MemberId memberId) {

--- a/src/main/java/makeus/cmc/malmo/domain/service/CoupleDomainService.java
+++ b/src/main/java/makeus/cmc/malmo/domain/service/CoupleDomainService.java
@@ -1,10 +1,14 @@
 package makeus.cmc.malmo.domain.service;
 
 import lombok.RequiredArgsConstructor;
+import makeus.cmc.malmo.application.port.out.LoadCoupleCodePort;
+import makeus.cmc.malmo.application.port.out.SaveCoupleCodePort;
+import makeus.cmc.malmo.domain.exception.CoupleCodeNotFoundException;
 import makeus.cmc.malmo.domain.model.couple.Couple;
 import makeus.cmc.malmo.domain.model.couple.CoupleState;
 import makeus.cmc.malmo.domain.model.member.CoupleCode;
 import makeus.cmc.malmo.domain.model.member.Member;
+import makeus.cmc.malmo.domain.model.value.MemberId;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -13,13 +17,28 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class CoupleDomainService {
 
-    public Couple createCouple(Member member, CoupleCode coupleCode) {
+    private final LoadCoupleCodePort loadCoupleCodePort;
+    private final SaveCoupleCodePort saveCoupleCodePort;
+
+    @Transactional
+    public Couple createCoupleByCoupleCode(Member member, CoupleCode coupleCode) {
+        CoupleCode memberCoupleCode = loadCoupleCodePort.loadCoupleCodeByMemberId(MemberId.of(member.getId()))
+                .orElseThrow(CoupleCodeNotFoundException::new);
+
+        expireCoupleCode(memberCoupleCode);
+        expireCoupleCode(coupleCode);
+
         return Couple.createCouple(
                 member.getId(),
                 coupleCode.getMemberId().getValue(),
                 coupleCode.getStartLoveDate(),
                 CoupleState.ALIVE
         );
+    }
+
+    private void expireCoupleCode(CoupleCode coupleCode) {
+        coupleCode.expire();
+        saveCoupleCodePort.saveCoupleCode(coupleCode);
     }
 
 }

--- a/src/main/java/makeus/cmc/malmo/domain/service/MemberDomainValidationService.java
+++ b/src/main/java/makeus/cmc/malmo/domain/service/MemberDomainValidationService.java
@@ -1,0 +1,22 @@
+package makeus.cmc.malmo.domain.service;
+
+import lombok.RequiredArgsConstructor;
+import makeus.cmc.malmo.application.port.out.ValidateMemberPort;
+import makeus.cmc.malmo.domain.model.value.MemberId;
+import makeus.cmc.malmo.adaptor.in.exception.NotCoupleMemberException;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class MemberDomainValidationService {
+
+    private final ValidateMemberPort validateMemberPort;
+
+    public void isMemberCouple(MemberId memberId) {
+        boolean coupleMember = validateMemberPort.isCoupleMember(memberId);
+
+        if (!coupleMember) {
+            throw new NotCoupleMemberException("커플 등록 전인 사용자입니다. 커플 등록 후 이용해주세요.");
+        }
+    }
+}

--- a/src/test/java/makeus/cmc/malmo/domain_service/CoupleDomainServiceTest.java
+++ b/src/test/java/makeus/cmc/malmo/domain_service/CoupleDomainServiceTest.java
@@ -1,7 +1,6 @@
 package makeus.cmc.malmo.domain_service;
 
 import makeus.cmc.malmo.domain.model.couple.Couple;
-import makeus.cmc.malmo.domain.model.couple.CoupleState;
 import makeus.cmc.malmo.domain.model.member.CoupleCode;
 import makeus.cmc.malmo.domain.model.member.Member;
 import makeus.cmc.malmo.domain.model.value.MemberId;
@@ -43,7 +42,7 @@ class CoupleDomainServiceTest {
             given(coupleCode.getStartLoveDate()).willReturn(startLoveDate);
 
             // When
-            Couple result = coupleDomainService.createCouple(member, coupleCode);
+            Couple result = coupleDomainService.createCoupleByCoupleCode(member, coupleCode);
 
             // Then
             assertThat(result).isNotNull();
@@ -66,7 +65,7 @@ class CoupleDomainServiceTest {
             given(coupleCode.getStartLoveDate()).willReturn(startLoveDate);
 
             // When
-            Couple result = coupleDomainService.createCouple(member, coupleCode);
+            Couple result = coupleDomainService.createCoupleByCoupleCode(member, coupleCode);
 
             // Then
             assertThat(result).isNotNull();
@@ -89,7 +88,7 @@ class CoupleDomainServiceTest {
             given(coupleCode.getStartLoveDate()).willReturn(todayDate);
 
             // When
-            Couple result = coupleDomainService.createCouple(member, coupleCode);
+            Couple result = coupleDomainService.createCoupleByCoupleCode(member, coupleCode);
 
             // Then
             assertThat(result).isNotNull();
@@ -112,7 +111,7 @@ class CoupleDomainServiceTest {
             given(coupleCode.getStartLoveDate()).willReturn(pastDate);
 
             // When
-            Couple result = coupleDomainService.createCouple(member, coupleCode);
+            Couple result = coupleDomainService.createCoupleByCoupleCode(member, coupleCode);
 
             // Then
             assertThat(result).isNotNull();
@@ -135,7 +134,7 @@ class CoupleDomainServiceTest {
             given(coupleCode.getStartLoveDate()).willReturn(startLoveDate);
 
             // When
-            Couple result = coupleDomainService.createCouple(member, coupleCode);
+            Couple result = coupleDomainService.createCoupleByCoupleCode(member, coupleCode);
 
             // Then
             assertThat(result).isNotNull();
@@ -158,7 +157,7 @@ class CoupleDomainServiceTest {
             given(coupleCode.getStartLoveDate()).willReturn(startLoveDate);
 
             // When
-            Couple result = coupleDomainService.createCouple(member, coupleCode);
+            Couple result = coupleDomainService.createCoupleByCoupleCode(member, coupleCode);
 
             // Then
             assertThat(result).isNotNull();

--- a/src/test/java/makeus/cmc/malmo/domain_service/CoupleDomainServiceTest.java
+++ b/src/test/java/makeus/cmc/malmo/domain_service/CoupleDomainServiceTest.java
@@ -1,5 +1,7 @@
 package makeus.cmc.malmo.domain_service;
 
+import makeus.cmc.malmo.application.port.out.LoadCoupleCodePort;
+import makeus.cmc.malmo.application.port.out.SaveCoupleCodePort;
 import makeus.cmc.malmo.domain.model.couple.Couple;
 import makeus.cmc.malmo.domain.model.member.CoupleCode;
 import makeus.cmc.malmo.domain.model.member.Member;
@@ -10,9 +12,11 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDate;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.*;
@@ -20,6 +24,12 @@ import static org.mockito.BDDMockito.*;
 @ExtendWith(MockitoExtension.class)
 @DisplayName("CoupleDomainService 단위 테스트")
 class CoupleDomainServiceTest {
+
+    @Mock
+    LoadCoupleCodePort loadCoupleCodePort;
+
+    @Mock
+    SaveCoupleCodePort saveCoupleCodePort;
 
     @InjectMocks
     private CoupleDomainService coupleDomainService;
@@ -34,10 +44,13 @@ class CoupleDomainServiceTest {
             // Given
             Member member = mock(Member.class);
             CoupleCode coupleCode = mock(CoupleCode.class);
+            CoupleCode memberCoupleCode = mock(CoupleCode.class);
             MemberId coupleCodeMemberId = MemberId.of(2L);
             LocalDate startLoveDate = LocalDate.of(2024, 1, 1);
 
             given(member.getId()).willReturn(1L);
+            given(loadCoupleCodePort.loadCoupleCodeByMemberId(MemberId.of(1L)))
+                    .willReturn(Optional.of(memberCoupleCode));
             given(coupleCode.getMemberId()).willReturn(coupleCodeMemberId);
             given(coupleCode.getStartLoveDate()).willReturn(startLoveDate);
 
@@ -46,9 +59,13 @@ class CoupleDomainServiceTest {
 
             // Then
             assertThat(result).isNotNull();
-            then(member).should().getId();
+            then(member).should(times(2)).getId();
             then(coupleCode).should().getMemberId();
             then(coupleCode).should().getStartLoveDate();
+            then(memberCoupleCode).should().expire();
+            then(coupleCode).should().expire();
+            then(saveCoupleCodePort).should().saveCoupleCode(memberCoupleCode);
+            then(saveCoupleCodePort).should().saveCoupleCode(coupleCode);
         }
 
         @Test
@@ -57,10 +74,13 @@ class CoupleDomainServiceTest {
             // Given
             Member member = mock(Member.class);
             CoupleCode coupleCode = mock(CoupleCode.class);
+            CoupleCode memberCoupleCode = mock(CoupleCode.class);
             MemberId coupleCodeMemberId = MemberId.of(5L);
             LocalDate startLoveDate = LocalDate.of(2023, 6, 15);
 
             given(member.getId()).willReturn(3L);
+            given(loadCoupleCodePort.loadCoupleCodeByMemberId(MemberId.of(3L)))
+                    .willReturn(Optional.of(memberCoupleCode));
             given(coupleCode.getMemberId()).willReturn(coupleCodeMemberId);
             given(coupleCode.getStartLoveDate()).willReturn(startLoveDate);
 
@@ -69,9 +89,13 @@ class CoupleDomainServiceTest {
 
             // Then
             assertThat(result).isNotNull();
-            then(member).should().getId();
+            then(member).should(times(2)).getId();
             then(coupleCode).should().getMemberId();
             then(coupleCode).should().getStartLoveDate();
+            then(memberCoupleCode).should().expire();
+            then(coupleCode).should().expire();
+            then(saveCoupleCodePort).should().saveCoupleCode(memberCoupleCode);
+            then(saveCoupleCodePort).should().saveCoupleCode(coupleCode);
         }
 
         @Test
@@ -80,10 +104,13 @@ class CoupleDomainServiceTest {
             // Given
             Member member = mock(Member.class);
             CoupleCode coupleCode = mock(CoupleCode.class);
+            CoupleCode memberCoupleCode = mock(CoupleCode.class);
             MemberId coupleCodeMemberId = MemberId.of(2L);
             LocalDate todayDate = LocalDate.now();
 
             given(member.getId()).willReturn(1L);
+            given(loadCoupleCodePort.loadCoupleCodeByMemberId(MemberId.of(1L)))
+                    .willReturn(Optional.of(memberCoupleCode));
             given(coupleCode.getMemberId()).willReturn(coupleCodeMemberId);
             given(coupleCode.getStartLoveDate()).willReturn(todayDate);
 
@@ -92,9 +119,13 @@ class CoupleDomainServiceTest {
 
             // Then
             assertThat(result).isNotNull();
-            then(member).should().getId();
+            then(member).should(times(2)).getId();
             then(coupleCode).should().getMemberId();
             then(coupleCode).should().getStartLoveDate();
+            then(memberCoupleCode).should().expire();
+            then(coupleCode).should().expire();
+            then(saveCoupleCodePort).should().saveCoupleCode(memberCoupleCode);
+            then(saveCoupleCodePort).should().saveCoupleCode(coupleCode);
         }
 
         @Test
@@ -103,10 +134,13 @@ class CoupleDomainServiceTest {
             // Given
             Member member = mock(Member.class);
             CoupleCode coupleCode = mock(CoupleCode.class);
+            CoupleCode memberCoupleCode = mock(CoupleCode.class);
             MemberId coupleCodeMemberId = MemberId.of(2L);
             LocalDate pastDate = LocalDate.of(2020, 1, 1);
 
             given(member.getId()).willReturn(1L);
+            given(loadCoupleCodePort.loadCoupleCodeByMemberId(MemberId.of(1L)))
+                    .willReturn(Optional.of(memberCoupleCode));
             given(coupleCode.getMemberId()).willReturn(coupleCodeMemberId);
             given(coupleCode.getStartLoveDate()).willReturn(pastDate);
 
@@ -115,9 +149,13 @@ class CoupleDomainServiceTest {
 
             // Then
             assertThat(result).isNotNull();
-            then(member).should().getId();
+            then(member).should(times(2)).getId();
             then(coupleCode).should().getMemberId();
             then(coupleCode).should().getStartLoveDate();
+            then(memberCoupleCode).should().expire();
+            then(coupleCode).should().expire();
+            then(saveCoupleCodePort).should().saveCoupleCode(memberCoupleCode);
+            then(saveCoupleCodePort).should().saveCoupleCode(coupleCode);
         }
 
         @Test
@@ -126,10 +164,13 @@ class CoupleDomainServiceTest {
             // Given
             Member member = mock(Member.class);
             CoupleCode coupleCode = mock(CoupleCode.class);
+            CoupleCode memberCoupleCode = mock(CoupleCode.class);
             MemberId coupleCodeMemberId = MemberId.of(Long.MAX_VALUE);
             LocalDate startLoveDate = LocalDate.of(2024, 1, 1);
 
             given(member.getId()).willReturn(Long.MAX_VALUE - 1);
+            given(loadCoupleCodePort.loadCoupleCodeByMemberId(MemberId.of(Long.MAX_VALUE - 1)))
+                    .willReturn(Optional.of(memberCoupleCode));
             given(coupleCode.getMemberId()).willReturn(coupleCodeMemberId);
             given(coupleCode.getStartLoveDate()).willReturn(startLoveDate);
 
@@ -138,9 +179,13 @@ class CoupleDomainServiceTest {
 
             // Then
             assertThat(result).isNotNull();
-            then(member).should().getId();
+            then(member).should(times(2)).getId();
             then(coupleCode).should().getMemberId();
             then(coupleCode).should().getStartLoveDate();
+            then(memberCoupleCode).should().expire();
+            then(coupleCode).should().expire();
+            then(saveCoupleCodePort).should().saveCoupleCode(memberCoupleCode);
+            then(saveCoupleCodePort).should().saveCoupleCode(coupleCode);
         }
 
         @Test
@@ -149,10 +194,13 @@ class CoupleDomainServiceTest {
             // Given
             Member member = mock(Member.class);
             CoupleCode coupleCode = mock(CoupleCode.class);
+            CoupleCode memberCoupleCode = mock(CoupleCode.class);
             MemberId coupleCodeMemberId = MemberId.of(2L);
             LocalDate startLoveDate = LocalDate.of(2024, 1, 1);
 
             given(member.getId()).willReturn(1L);
+            given(loadCoupleCodePort.loadCoupleCodeByMemberId(MemberId.of(1L)))
+                    .willReturn(Optional.of(memberCoupleCode));
             given(coupleCode.getMemberId()).willReturn(coupleCodeMemberId);
             given(coupleCode.getStartLoveDate()).willReturn(startLoveDate);
 
@@ -161,9 +209,13 @@ class CoupleDomainServiceTest {
 
             // Then
             assertThat(result).isNotNull();
-            then(member).should().getId();
+            then(member).should(times(2)).getId();
             then(coupleCode).should().getMemberId();
             then(coupleCode).should().getStartLoveDate();
+            then(memberCoupleCode).should().expire();
+            then(coupleCode).should().expire();
+            then(saveCoupleCodePort).should().saveCoupleCode(memberCoupleCode);
+            then(saveCoupleCodePort).should().saveCoupleCode(coupleCode);
         }
     }
 }

--- a/src/test/java/makeus/cmc/malmo/service/CoupleServiceTest.java
+++ b/src/test/java/makeus/cmc/malmo/service/CoupleServiceTest.java
@@ -69,7 +69,7 @@ class CoupleServiceTest {
 
             given(memberDomainService.getMemberById(MemberId.of(userId))).willReturn(member);
             given(coupleCodeDomainService.getCoupleCodeByInviteCode(inviteCode)).willReturn(coupleCode);
-            given(coupleDomainService.createCouple(member, coupleCode)).willReturn(createdCouple);
+            given(coupleDomainService.createCoupleByCoupleCode(member, coupleCode)).willReturn(createdCouple);
             given(saveCouplePort.saveCouple(createdCouple)).willReturn(savedCouple);
 
             // When
@@ -81,7 +81,7 @@ class CoupleServiceTest {
 
             then(memberDomainService).should().getMemberById(MemberId.of(userId));
             then(coupleCodeDomainService).should().getCoupleCodeByInviteCode(inviteCode);
-            then(coupleDomainService).should().createCouple(member, coupleCode);
+            then(coupleDomainService).should().createCoupleByCoupleCode(member, coupleCode);
             then(saveCouplePort).should().saveCouple(createdCouple);
         }
 
@@ -106,7 +106,7 @@ class CoupleServiceTest {
 
             then(memberDomainService).should().getMemberById(MemberId.of(userId));
             then(coupleCodeDomainService).should(never()).getCoupleCodeByInviteCode(any());
-            then(coupleDomainService).should(never()).createCouple(any(), any());
+            then(coupleDomainService).should(never()).createCoupleByCoupleCode(any(), any());
             then(saveCouplePort).should(never()).saveCouple(any());
         }
 
@@ -134,7 +134,7 @@ class CoupleServiceTest {
 
             then(memberDomainService).should().getMemberById(MemberId.of(userId));
             then(coupleCodeDomainService).should().getCoupleCodeByInviteCode(invalidInviteCode);
-            then(coupleDomainService).should(never()).createCouple(any(), any());
+            then(coupleDomainService).should(never()).createCoupleByCoupleCode(any(), any());
             then(saveCouplePort).should(never()).saveCouple(any());
         }
     }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> - #MM-18

## 📝 작업 내용

> - 커플 전용 API 요청 사용자가 커플로 등록되어 있는지 확인하기 위해 Spring AOP 도입
> - sign-up 경로를 members/onboarding으로 변경
> - Couple 연결 시 CoupleCode를 재사용할 수 없도록 변경