### PR TITLE
커플 연동 시 초대 코드 화면 전환을 위한 SSE 로직 구현

### DIFF
--- a/src/main/java/makeus/cmc/malmo/adaptor/in/web/controller/SseController.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/in/web/controller/SseController.java
@@ -1,0 +1,35 @@
+package makeus.cmc.malmo.adaptor.in.web.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import makeus.cmc.malmo.application.port.in.ConnectSseUseCase;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@Tag(name = "SSE Connection API", description = "Server-Sent Event(SSE) 연결 API")
+@RestController
+@RequestMapping("/sse")
+@RequiredArgsConstructor
+public class SseController {
+
+    private final ConnectSseUseCase connectSseUseCase;
+
+    @Operation(
+            summary = "SSE 연결",
+            description = "사용자의 SSE 연결을 설정합니다. JWT 토큰이 필요합니다. BaseResponse를 사용하지 않습니다."
+    )
+    @GetMapping(value = "/connect", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public SseEmitter connectSse(@AuthenticationPrincipal User user) {
+        ConnectSseUseCase.SseConnectionCommand command = ConnectSseUseCase.SseConnectionCommand.builder()
+                .userId(Long.valueOf(user.getUsername()))
+                .build();
+        return connectSseUseCase.connectSse(command).getSseEmitter();
+    }
+
+}

--- a/src/main/java/makeus/cmc/malmo/adaptor/out/SseEmitterAdapter.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/out/SseEmitterAdapter.java
@@ -1,10 +1,9 @@
 package makeus.cmc.malmo.adaptor.out;
 
+import lombok.extern.slf4j.Slf4j;
 import makeus.cmc.malmo.adaptor.out.exception.SseConnectionException;
 import makeus.cmc.malmo.application.port.out.ConnectSsePort;
 import makeus.cmc.malmo.application.port.out.SendSseEventPort;
-
-import lombok.extern.slf4j.Slf4j;
 import makeus.cmc.malmo.domain.model.value.MemberId;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;

--- a/src/main/java/makeus/cmc/malmo/adaptor/out/SseEmitterAdapter.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/out/SseEmitterAdapter.java
@@ -1,0 +1,87 @@
+package makeus.cmc.malmo.adaptor.out;
+
+import makeus.cmc.malmo.application.port.out.ConnectSsePort;
+import makeus.cmc.malmo.application.port.out.SendSseEventPort;
+
+import lombok.extern.slf4j.Slf4j;
+import makeus.cmc.malmo.domain.model.value.MemberId;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Slf4j
+@Component
+public class SseEmitterAdapter implements SendSseEventPort, ConnectSsePort {
+    private static final long TIMEOUT = 10 * 60 * 1000L; // 10분
+    private static final int MAX_SIZE = 1000;
+
+    private final Map<Long, SseEmitter> emitters = new ConcurrentHashMap<>();
+
+    @Override
+    public void connect(MemberId memberId) {
+        if (emitters.size() >= MAX_SIZE) {
+            removeRandomEmitter();
+        }
+
+        Long memberIdValue = memberId.getValue();
+        if (emitters.containsKey(memberIdValue)) {
+            emitters.get(memberIdValue).complete();
+            emitters.remove(memberIdValue);
+        }
+
+        SseEmitter emitter = new SseEmitter(TIMEOUT);
+        emitter.onTimeout(() -> {
+            try {
+                emitter.send(SseEmitter.event()
+                        .name("timeout")
+                        .data("connection_timeout"));
+            } catch (IOException e) {
+                log.warn("타임아웃 이벤트 전송 실패", e);
+            } finally {
+                emitters.remove(memberIdValue);
+            }
+        });
+        emitter.onCompletion(() ->
+                emitters.remove(memberIdValue));
+        emitter.onError((e) ->
+                emitters.remove(memberIdValue));
+
+        try {
+            emitter.send(SseEmitter.event()
+                            .name("connected")
+                            .data("connected"));
+        } catch (IOException e) {
+            log.error("초기 연결 실패", e);
+        }
+
+        emitters.put(memberIdValue, emitter);
+    }
+
+    @Override
+    public void sendToMember(MemberId memberId, NotificationEvent event) {
+        Long memberIdValue = memberId.getValue();
+        SseEmitter emitter = emitters.get(memberIdValue);
+        if (emitter == null) {
+            return;
+        }
+
+        try {
+            emitter.send(SseEmitter.event()
+                    .name(event.getEventName())
+                    .data(event.getData()));
+        } catch (IOException e) {
+            emitters.remove(memberIdValue);
+        }
+    }
+
+    private void removeRandomEmitter() {
+        if (!emitters.isEmpty()) {
+            Long key = emitters.keySet().iterator().next();
+            emitters.get(key).complete();
+            emitters.remove(key);
+        }
+    }
+}

--- a/src/main/java/makeus/cmc/malmo/adaptor/out/SseEmitterAdapter.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/out/SseEmitterAdapter.java
@@ -76,7 +76,7 @@ public class SseEmitterAdapter implements SendSseEventPort, ConnectSsePort {
         try {
             emitter.send(SseEmitter.event()
                     .id(memberIdValue + "_" + System.currentTimeMillis()) // 각 이벤트에 고유 ID 부여
-                    .name(event.getEventName())
+                    .name(event.getEventType().getEventName())
                     .data(event.getData()));
         } catch (IOException | IllegalStateException e) {
             log.error("Failed to send SSE event to member: {}. Removing emitter.", memberIdValue, e);

--- a/src/main/java/makeus/cmc/malmo/adaptor/out/exception/SseConnectionException.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/out/exception/SseConnectionException.java
@@ -1,0 +1,7 @@
+package makeus.cmc.malmo.adaptor.out.exception;
+
+public class SseConnectionException extends RuntimeException {
+    public SseConnectionException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/MemberPersistenceAdapter.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/MemberPersistenceAdapter.java
@@ -3,7 +3,6 @@ package makeus.cmc.malmo.adaptor.out.persistence;
 import lombok.RequiredArgsConstructor;
 import makeus.cmc.malmo.adaptor.out.persistence.entity.member.MemberEntity;
 import makeus.cmc.malmo.adaptor.out.persistence.entity.member.ProviderJpa;
-import makeus.cmc.malmo.adaptor.out.persistence.entity.value.InviteCodeEntityValue;
 import makeus.cmc.malmo.adaptor.out.persistence.mapper.MemberMapper;
 import makeus.cmc.malmo.adaptor.out.persistence.repository.MemberRepository;
 import makeus.cmc.malmo.application.port.out.LoadInviteCodePort;

--- a/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/entity/value/CoupleEntityId.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/entity/value/CoupleEntityId.java
@@ -12,7 +12,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Embeddable
 public class CoupleEntityId {
-    @Column(name = "couple_id", nullable = false)
+    @Column(name = "couple_id")
     Long value;
 
     public static CoupleEntityId of(Long value) {

--- a/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/entity/value/InviteCodeEntityValue.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/entity/value/InviteCodeEntityValue.java
@@ -12,7 +12,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Embeddable
 public class InviteCodeEntityValue {
-    @Column(name = "invite_code", nullable = false, unique = true)
+    @Column(name = "invite_code", unique = true)
     String value;
 
     public static InviteCodeEntityValue of(String value) {

--- a/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/repository/MemberRepository.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/repository/MemberRepository.java
@@ -2,7 +2,6 @@ package makeus.cmc.malmo.adaptor.out.persistence.repository;
 
 import makeus.cmc.malmo.adaptor.out.persistence.entity.member.MemberEntity;
 import makeus.cmc.malmo.adaptor.out.persistence.entity.member.ProviderJpa;
-import makeus.cmc.malmo.adaptor.out.persistence.entity.value.InviteCodeEntityValue;
 import makeus.cmc.malmo.adaptor.out.persistence.repository.custom.MemberRepositoryCustom;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;

--- a/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/repository/MemberRepository.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/repository/MemberRepository.java
@@ -13,6 +13,6 @@ public interface MemberRepository extends JpaRepository<MemberEntity, Long>, Mem
 
     Optional<MemberEntity> findByProviderJpaAndProviderId(ProviderJpa providerJpa, String providerId);
 
-    @Query("select m from MemberEntity m where m.inviteCodeEntityValue.value = ?1 and m.memberStateJpa = 'ACTIVE'")
+    @Query("select m from MemberEntity m where m.inviteCodeEntityValue.value = ?1 and m.memberStateJpa = 'ALIVE'")
     Optional<MemberEntity> findMemberEntityByInviteCode(String inviteCode);
 }

--- a/src/main/java/makeus/cmc/malmo/application/port/in/ConnectSseUseCase.java
+++ b/src/main/java/makeus/cmc/malmo/application/port/in/ConnectSseUseCase.java
@@ -12,7 +12,6 @@ public interface ConnectSseUseCase {
     @Builder
     class SseConnectionCommand {
         private Long userId;
-        private String coupleCode;
     }
 
     @Data

--- a/src/main/java/makeus/cmc/malmo/application/port/in/ConnectSseUseCase.java
+++ b/src/main/java/makeus/cmc/malmo/application/port/in/ConnectSseUseCase.java
@@ -1,0 +1,23 @@
+package makeus.cmc.malmo.application.port.in;
+
+import lombok.Builder;
+import lombok.Data;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+public interface ConnectSseUseCase {
+
+    SseConnectionResponse connectSse(SseConnectionCommand command);
+
+    @Data
+    @Builder
+    class SseConnectionCommand {
+        private Long userId;
+        private String coupleCode;
+    }
+
+    @Data
+    @Builder
+    class SseConnectionResponse {
+        private SseEmitter sseEmitter;
+    }
+}

--- a/src/main/java/makeus/cmc/malmo/application/port/out/ConnectSsePort.java
+++ b/src/main/java/makeus/cmc/malmo/application/port/out/ConnectSsePort.java
@@ -1,7 +1,5 @@
 package makeus.cmc.malmo.application.port.out;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
 import makeus.cmc.malmo.domain.model.value.MemberId;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 

--- a/src/main/java/makeus/cmc/malmo/application/port/out/ConnectSsePort.java
+++ b/src/main/java/makeus/cmc/malmo/application/port/out/ConnectSsePort.java
@@ -1,0 +1,10 @@
+package makeus.cmc.malmo.application.port.out;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import makeus.cmc.malmo.domain.model.value.MemberId;
+
+public interface ConnectSsePort {
+    void connect(MemberId memberId);
+}
+

--- a/src/main/java/makeus/cmc/malmo/application/port/out/ConnectSsePort.java
+++ b/src/main/java/makeus/cmc/malmo/application/port/out/ConnectSsePort.java
@@ -6,6 +6,6 @@ import makeus.cmc.malmo.domain.model.value.MemberId;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 public interface ConnectSsePort {
-    void connect(MemberId memberId);
+    SseEmitter connect(MemberId memberId);
 }
 

--- a/src/main/java/makeus/cmc/malmo/application/port/out/GetSseEmitterPort.java
+++ b/src/main/java/makeus/cmc/malmo/application/port/out/GetSseEmitterPort.java
@@ -1,11 +1,8 @@
 package makeus.cmc.malmo.application.port.out;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
 import makeus.cmc.malmo.domain.model.value.MemberId;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
-public interface ConnectSsePort {
-    void connect(MemberId memberId);
+public interface GetSseEmitterPort {
+    SseEmitter getEmitter(MemberId memberId);
 }
-

--- a/src/main/java/makeus/cmc/malmo/application/port/out/SendSseEventPort.java
+++ b/src/main/java/makeus/cmc/malmo/application/port/out/SendSseEventPort.java
@@ -1,0 +1,17 @@
+package makeus.cmc.malmo.application.port.out;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import makeus.cmc.malmo.domain.model.value.MemberId;
+
+public interface SendSseEventPort {
+    void sendToMember(MemberId memberId, NotificationEvent event);
+
+    @Getter
+    @AllArgsConstructor
+    class NotificationEvent {
+        private String eventName;
+        private Object data;
+    }
+}
+

--- a/src/main/java/makeus/cmc/malmo/application/port/out/SendSseEventPort.java
+++ b/src/main/java/makeus/cmc/malmo/application/port/out/SendSseEventPort.java
@@ -10,8 +10,16 @@ public interface SendSseEventPort {
     @Getter
     @AllArgsConstructor
     class NotificationEvent {
-        private String eventName;
+        private SseEventType eventType;
         private Object data;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    enum SseEventType {
+        COUPLE_CONNECTED("couple_connected");
+
+        private final String eventName;
     }
 }
 

--- a/src/main/java/makeus/cmc/malmo/application/service/CoupleService.java
+++ b/src/main/java/makeus/cmc/malmo/application/service/CoupleService.java
@@ -13,6 +13,8 @@ import makeus.cmc.malmo.domain.service.CoupleDomainService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import static makeus.cmc.malmo.application.port.out.SendSseEventPort.SseEventType.*;
+
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
@@ -43,7 +45,7 @@ public class CoupleService implements CoupleLinkUseCase {
         sendSseEventPort.sendToMember(
                 MemberId.of(partner.getId()),
                 new SendSseEventPort.NotificationEvent(
-                        "couple_connected", savedCouple.getId())
+                        COUPLE_CONNECTED, savedCouple.getId())
         );
 
         return CoupleLinkResponse.builder()

--- a/src/main/java/makeus/cmc/malmo/application/service/CoupleService.java
+++ b/src/main/java/makeus/cmc/malmo/application/service/CoupleService.java
@@ -8,12 +8,12 @@ import makeus.cmc.malmo.domain.model.couple.Couple;
 import makeus.cmc.malmo.domain.model.member.Member;
 import makeus.cmc.malmo.domain.model.value.InviteCodeValue;
 import makeus.cmc.malmo.domain.model.value.MemberId;
-import makeus.cmc.malmo.domain.service.InviteCodeDomainService;
 import makeus.cmc.malmo.domain.service.CoupleDomainService;
+import makeus.cmc.malmo.domain.service.InviteCodeDomainService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import static makeus.cmc.malmo.application.port.out.SendSseEventPort.SseEventType.*;
+import static makeus.cmc.malmo.application.port.out.SendSseEventPort.SseEventType.COUPLE_CONNECTED;
 
 @Service
 @Transactional(readOnly = true)

--- a/src/main/java/makeus/cmc/malmo/application/service/MemberInfoService.java
+++ b/src/main/java/makeus/cmc/malmo/application/service/MemberInfoService.java
@@ -2,13 +2,12 @@ package makeus.cmc.malmo.application.service;
 
 import lombok.RequiredArgsConstructor;
 import makeus.cmc.malmo.adaptor.in.aop.CheckCoupleMember;
-import makeus.cmc.malmo.domain.exception.MemberNotFoundException;
 import makeus.cmc.malmo.application.port.in.GetMemberUseCase;
 import makeus.cmc.malmo.application.port.in.GetPartnerUseCase;
 import makeus.cmc.malmo.application.port.out.LoadMemberPort;
 import makeus.cmc.malmo.application.port.out.LoadPartnerPort;
+import makeus.cmc.malmo.domain.exception.MemberNotFoundException;
 import makeus.cmc.malmo.domain.model.member.MemberState;
-import org.hibernate.annotations.Check;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/src/main/java/makeus/cmc/malmo/application/service/SignInService.java
+++ b/src/main/java/makeus/cmc/malmo/application/service/SignInService.java
@@ -5,8 +5,6 @@ import makeus.cmc.malmo.adaptor.out.jwt.TokenInfo;
 import makeus.cmc.malmo.application.port.in.SignInUseCase;
 import makeus.cmc.malmo.application.port.out.*;
 import makeus.cmc.malmo.domain.model.member.Member;
-import makeus.cmc.malmo.domain.model.member.MemberRole;
-import makeus.cmc.malmo.domain.model.member.MemberState;
 import makeus.cmc.malmo.domain.model.member.Provider;
 import makeus.cmc.malmo.domain.service.MemberDomainService;
 import org.springframework.stereotype.Service;

--- a/src/main/java/makeus/cmc/malmo/application/service/SignUpService.java
+++ b/src/main/java/makeus/cmc/malmo/application/service/SignUpService.java
@@ -2,7 +2,7 @@ package makeus.cmc.malmo.application.service;
 
 import lombok.RequiredArgsConstructor;
 import makeus.cmc.malmo.application.port.in.SignUpUseCase;
-import makeus.cmc.malmo.application.port.out.*;
+import makeus.cmc.malmo.application.port.out.SaveMemberPort;
 import makeus.cmc.malmo.domain.model.member.Member;
 import makeus.cmc.malmo.domain.model.value.InviteCodeValue;
 import makeus.cmc.malmo.domain.model.value.MemberId;

--- a/src/main/java/makeus/cmc/malmo/application/service/SseService.java
+++ b/src/main/java/makeus/cmc/malmo/application/service/SseService.java
@@ -1,0 +1,29 @@
+package makeus.cmc.malmo.application.service;
+
+import lombok.RequiredArgsConstructor;
+import makeus.cmc.malmo.application.port.in.ConnectSseUseCase;
+import makeus.cmc.malmo.application.port.out.ConnectSsePort;
+import makeus.cmc.malmo.application.port.out.GetSseEmitterPort;
+import makeus.cmc.malmo.domain.model.value.MemberId;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class SseService implements ConnectSseUseCase {
+
+    private final ConnectSsePort connectSsePort;
+    private final GetSseEmitterPort getSseEmitterPort;
+
+    @Override
+    public SseConnectionResponse connectSse(SseConnectionCommand command) {
+        MemberId memberId = MemberId.of(command.getUserId());
+        connectSsePort.connect(memberId);
+        SseEmitter emitter = getSseEmitterPort.getEmitter(memberId);
+        return SseConnectionResponse.builder()
+                .sseEmitter(emitter)
+                .build();
+    }
+}

--- a/src/main/java/makeus/cmc/malmo/application/service/SseService.java
+++ b/src/main/java/makeus/cmc/malmo/application/service/SseService.java
@@ -3,7 +3,6 @@ package makeus.cmc.malmo.application.service;
 import lombok.RequiredArgsConstructor;
 import makeus.cmc.malmo.application.port.in.ConnectSseUseCase;
 import makeus.cmc.malmo.application.port.out.ConnectSsePort;
-import makeus.cmc.malmo.application.port.out.GetSseEmitterPort;
 import makeus.cmc.malmo.domain.model.value.MemberId;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,13 +14,11 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 public class SseService implements ConnectSseUseCase {
 
     private final ConnectSsePort connectSsePort;
-    private final GetSseEmitterPort getSseEmitterPort;
 
     @Override
     public SseConnectionResponse connectSse(SseConnectionCommand command) {
         MemberId memberId = MemberId.of(command.getUserId());
-        connectSsePort.connect(memberId);
-        SseEmitter emitter = getSseEmitterPort.getEmitter(memberId);
+        SseEmitter emitter = connectSsePort.connect(memberId);
         return SseConnectionResponse.builder()
                 .sseEmitter(emitter)
                 .build();

--- a/src/main/java/makeus/cmc/malmo/application/service/TermsAgreementService.java
+++ b/src/main/java/makeus/cmc/malmo/application/service/TermsAgreementService.java
@@ -2,7 +2,6 @@ package makeus.cmc.malmo.application.service;
 
 import lombok.RequiredArgsConstructor;
 import makeus.cmc.malmo.application.port.in.UpdateTermsAgreementUseCase;
-import makeus.cmc.malmo.application.port.out.LoadTermsAgreementPort;
 import makeus.cmc.malmo.application.port.out.SaveMemberTermsAgreement;
 import makeus.cmc.malmo.domain.model.terms.MemberTermsAgreement;
 import makeus.cmc.malmo.domain.model.value.MemberId;

--- a/src/main/java/makeus/cmc/malmo/domain/service/InviteCodeDomainService.java
+++ b/src/main/java/makeus/cmc/malmo/domain/service/InviteCodeDomainService.java
@@ -1,9 +1,12 @@
 package makeus.cmc.malmo.domain.service;
 
 import lombok.RequiredArgsConstructor;
-import makeus.cmc.malmo.application.port.out.*;
-import makeus.cmc.malmo.domain.exception.InviteCodeNotFoundException;
+import makeus.cmc.malmo.application.port.out.GenerateInviteCodePort;
+import makeus.cmc.malmo.application.port.out.LoadInviteCodePort;
+import makeus.cmc.malmo.application.port.out.LoadMemberPort;
+import makeus.cmc.malmo.application.port.out.ValidateInviteCodePort;
 import makeus.cmc.malmo.domain.exception.InviteCodeGenerateFailedException;
+import makeus.cmc.malmo.domain.exception.InviteCodeNotFoundException;
 import makeus.cmc.malmo.domain.exception.UsedInviteCodeException;
 import makeus.cmc.malmo.domain.model.member.Member;
 import makeus.cmc.malmo.domain.model.value.InviteCodeValue;

--- a/src/main/java/makeus/cmc/malmo/domain/service/LoveTypeDomainService.java
+++ b/src/main/java/makeus/cmc/malmo/domain/service/LoveTypeDomainService.java
@@ -1,10 +1,10 @@
 package makeus.cmc.malmo.domain.service;
 
 import lombok.RequiredArgsConstructor;
-import makeus.cmc.malmo.domain.exception.LoveTypeNotFoundException;
-import makeus.cmc.malmo.domain.exception.LoveTypeQuestionNotFoundException;
 import makeus.cmc.malmo.application.port.out.LoadLoveTypePort;
 import makeus.cmc.malmo.application.port.out.LoadLoveTypeQuestionsPort;
+import makeus.cmc.malmo.domain.exception.LoveTypeNotFoundException;
+import makeus.cmc.malmo.domain.exception.LoveTypeQuestionNotFoundException;
 import makeus.cmc.malmo.domain.model.love_type.LoveType;
 import makeus.cmc.malmo.domain.model.love_type.LoveTypeCategory;
 import makeus.cmc.malmo.domain.model.love_type.LoveTypeQuestion;

--- a/src/main/java/makeus/cmc/malmo/domain/service/MemberDomainService.java
+++ b/src/main/java/makeus/cmc/malmo/domain/service/MemberDomainService.java
@@ -1,8 +1,8 @@
 package makeus.cmc.malmo.domain.service;
 
 import lombok.RequiredArgsConstructor;
-import makeus.cmc.malmo.domain.exception.MemberNotFoundException;
 import makeus.cmc.malmo.application.port.out.LoadMemberPort;
+import makeus.cmc.malmo.domain.exception.MemberNotFoundException;
 import makeus.cmc.malmo.domain.model.member.Member;
 import makeus.cmc.malmo.domain.model.member.MemberRole;
 import makeus.cmc.malmo.domain.model.member.MemberState;

--- a/src/main/java/makeus/cmc/malmo/domain/service/MemberDomainValidationService.java
+++ b/src/main/java/makeus/cmc/malmo/domain/service/MemberDomainValidationService.java
@@ -1,9 +1,9 @@
 package makeus.cmc.malmo.domain.service;
 
 import lombok.RequiredArgsConstructor;
+import makeus.cmc.malmo.adaptor.in.exception.NotCoupleMemberException;
 import makeus.cmc.malmo.application.port.out.ValidateMemberPort;
 import makeus.cmc.malmo.domain.model.value.MemberId;
-import makeus.cmc.malmo.adaptor.in.exception.NotCoupleMemberException;
 import org.springframework.stereotype.Component;
 
 @Component

--- a/src/main/java/makeus/cmc/malmo/domain/service/TermsAgreementDomainService.java
+++ b/src/main/java/makeus/cmc/malmo/domain/service/TermsAgreementDomainService.java
@@ -1,10 +1,10 @@
 package makeus.cmc.malmo.domain.service;
 
 import lombok.RequiredArgsConstructor;
-import makeus.cmc.malmo.domain.exception.TermsNotFoundException;
 import makeus.cmc.malmo.application.port.out.LoadTermsAgreementPort;
 import makeus.cmc.malmo.application.port.out.LoadTermsPort;
 import makeus.cmc.malmo.application.port.out.SaveMemberTermsAgreement;
+import makeus.cmc.malmo.domain.exception.TermsNotFoundException;
 import makeus.cmc.malmo.domain.model.terms.MemberTermsAgreement;
 import makeus.cmc.malmo.domain.model.terms.Terms;
 import makeus.cmc.malmo.domain.model.value.MemberId;

--- a/src/test/java/makeus/cmc/malmo/service/CoupleServiceTest.java
+++ b/src/test/java/makeus/cmc/malmo/service/CoupleServiceTest.java
@@ -1,5 +1,6 @@
 package makeus.cmc.malmo.service;
 
+import makeus.cmc.malmo.application.port.out.SendSseEventPort;
 import makeus.cmc.malmo.domain.exception.InviteCodeNotFoundException;
 import makeus.cmc.malmo.domain.exception.MemberNotFoundException;
 import makeus.cmc.malmo.application.port.in.CoupleLinkUseCase;
@@ -38,6 +39,9 @@ class CoupleServiceTest {
 
     @Mock
     private SaveCouplePort saveCouplePort;
+
+    @Mock
+    private SendSseEventPort sendSseEventPort;
 
     @InjectMocks
     private CoupleService coupleService;
@@ -82,6 +86,7 @@ class CoupleServiceTest {
             assertThat(response).isNotNull();
             assertThat(response.getCoupleId()).isEqualTo(coupleId);
 
+            then(sendSseEventPort).should().sendToMember(eq(MemberId.of(partnerId)), any(SendSseEventPort.NotificationEvent.class));
             then(inviteCodeDomainService).should().validateUsedInviteCode(inviteCodeValue);
             then(inviteCodeDomainService).should().getMemberByInviteCode(inviteCodeValue);
             then(coupleDomainService).should().createCoupleByInviteCode(MemberId.of(userId), MemberId.of(partnerId), startLoveDate);


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> - #MM-30

## 📝 작업 내용

> - SSE 설정 Adapter 추가
> - SSE 연결을 위한 엔드포인트 추가
> - 커플 연동 로직에 SSE Event Sender 추가

테스트 도중 Nullable 설정 오류로 커플 연동이 되지 않았던 문제 해결
