### PR TITLE
채팅 기록 모아보기 API 구현

### DIFF
--- a/src/main/java/makeus/cmc/malmo/adaptor/in/exception/ErrorCode.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/in/exception/ErrorCode.java
@@ -29,6 +29,7 @@ public enum ErrorCode {
     // 403 Forbidden
     FORBIDDEN(HttpStatus.FORBIDDEN, 40300, "접근 권한이 없습니다."),
     NOT_COUPLE_MEMBER(HttpStatus.FORBIDDEN, 40301, "커플 등록 전인 사용자입니다. 커플 등록 후 이용해주세요."),
+    MEMBER_ACCESS_DENIED(HttpStatus.FORBIDDEN, 40302, "사용자의 리소스 접근 권한이 없습니다."),
 
     // 404 Not Found
     NOT_FOUND(HttpStatus.NOT_FOUND, 40400, "요청한 리소스를 찾을 수 없습니다."),

--- a/src/main/java/makeus/cmc/malmo/adaptor/in/exception/GlobalExceptionHandler.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/in/exception/GlobalExceptionHandler.java
@@ -118,6 +118,12 @@ public class GlobalExceptionHandler {
         return ErrorResponse.of(ErrorCode.NOT_VALID_CHAT_ROOM);
     }
 
+    @ExceptionHandler({MemberAccessDeniedException.class})
+    public ResponseEntity<ErrorResponse> handleMemberAccessDeniedException(MemberAccessDeniedException e) {
+        log.error("[GlobalExceptionHandler: handleMemberAccessDeniedException 호출]", e);
+        return ErrorResponse.of(ErrorCode.MEMBER_ACCESS_DENIED);
+    }
+
 
 
 

--- a/src/main/java/makeus/cmc/malmo/adaptor/in/web/controller/ChatRoomController.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/in/web/controller/ChatRoomController.java
@@ -12,6 +12,7 @@ import makeus.cmc.malmo.adaptor.in.web.docs.SwaggerResponses;
 import makeus.cmc.malmo.adaptor.in.web.dto.BaseListResponse;
 import makeus.cmc.malmo.adaptor.in.web.dto.BaseResponse;
 import makeus.cmc.malmo.application.port.in.GetChatRoomListUseCase;
+import makeus.cmc.malmo.application.port.in.GetChatRoomMessagesUseCase;
 import makeus.cmc.malmo.application.port.in.GetChatRoomSummaryUseCase;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.User;
@@ -25,6 +26,7 @@ public class ChatRoomController {
 
     private final GetChatRoomSummaryUseCase getChatRoomSummaryUseCase;
     private final GetChatRoomListUseCase getChatRoomListUseCase;
+    private final GetChatRoomMessagesUseCase getChatRoomMessagesUseCase;
 
     @Operation(
             summary = "채팅방 요약 조회",
@@ -73,5 +75,31 @@ public class ChatRoomController {
                 .build();
 
         return BaseListResponse.success(getChatRoomListUseCase.getChatRoomList(command).getChatRoomList());
+    }
+
+    @Operation(
+            summary = "채팅방의 메시지 리스트 조회",
+            description = "채팅방의 메시지를 페이지네이션으로 조회합니다. 현재 채팅방과 달리 시간 오름차순으로 전달됩니다. JWT 토큰이 필요합니다.",
+            security = @SecurityRequirement(name = "Bearer Authentication")
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "채팅방 메시지 리스트 조회 성공",
+            content = @Content(schema = @Schema(implementation = SwaggerResponses.ChatMessageListSuccessResponse.class))
+    )
+    @ApiCommonResponses.RequireAuth
+    @GetMapping("/{chatRoomId}/messages")
+    public BaseResponse<BaseListResponse<GetChatRoomMessagesUseCase.ChatRoomMessageDto>> getCurrentChatRoomMessages(
+            @RequestParam(value = "page", defaultValue = "0") int page,
+            @RequestParam(value = "size", defaultValue = "10") int size,
+            @AuthenticationPrincipal User user, @PathVariable Long chatRoomId) {
+        GetChatRoomMessagesUseCase.GetChatRoomMessagesCommand command = GetChatRoomMessagesUseCase.GetChatRoomMessagesCommand.builder()
+                .userId(Long.valueOf(user.getUsername()))
+                .chatRoomId(chatRoomId)
+                .page(page)
+                .size(size)
+                .build();
+
+        return BaseListResponse.success(getChatRoomMessagesUseCase.getChatRoomMessages(command).getMessages());
     }
 }

--- a/src/main/java/makeus/cmc/malmo/adaptor/in/web/controller/ChatRoomController.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/in/web/controller/ChatRoomController.java
@@ -9,14 +9,13 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import makeus.cmc.malmo.adaptor.in.web.docs.ApiCommonResponses;
 import makeus.cmc.malmo.adaptor.in.web.docs.SwaggerResponses;
+import makeus.cmc.malmo.adaptor.in.web.dto.BaseListResponse;
 import makeus.cmc.malmo.adaptor.in.web.dto.BaseResponse;
+import makeus.cmc.malmo.application.port.in.GetChatRoomListUseCase;
 import makeus.cmc.malmo.application.port.in.GetChatRoomSummaryUseCase;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.User;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "채팅방 API", description = "사용자의 채팅방 관리 및 조회를 위한 API")
 @RestController
@@ -25,6 +24,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class ChatRoomController {
 
     private final GetChatRoomSummaryUseCase getChatRoomSummaryUseCase;
+    private final GetChatRoomListUseCase getChatRoomListUseCase;
 
     @Operation(
             summary = "채팅방 요약 조회",
@@ -46,5 +46,32 @@ public class ChatRoomController {
                 .build();
 
         return BaseResponse.success(getChatRoomSummaryUseCase.getChatRoomSummary(command));
+    }
+
+    @Operation(
+            summary = "채팅방 리스트 조회",
+            description = "조건에 부합하는 채팅방 리스트를 조회합니다. JWT 토큰이 필요합니다.",
+            security = @SecurityRequirement(name = "Bearer Authentication")
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "채팅방 리스트 조회 성공",
+            content = @Content(schema = @Schema(implementation = SwaggerResponses.ChatRoomListSuccessResponse.class))
+    )
+    @ApiCommonResponses.RequireAuth
+    @GetMapping
+    public BaseResponse<BaseListResponse<GetChatRoomListUseCase.GetChatRoomResponse>> getCurrentChatRoom(
+            @RequestParam(value = "page", defaultValue = "0") int page,
+            @RequestParam(value = "size", defaultValue = "10") int size,
+            @RequestParam(value = "keyword", defaultValue = "") String keyword,
+            @AuthenticationPrincipal User user) {
+        GetChatRoomListUseCase.GetChatRoomListCommand command = GetChatRoomListUseCase.GetChatRoomListCommand.builder()
+                .userId(Long.valueOf(user.getUsername()))
+                .keyword(keyword)
+                .page(page)
+                .size(size)
+                .build();
+
+        return BaseListResponse.success(getChatRoomListUseCase.getChatRoomList(command).getChatRoomList());
     }
 }

--- a/src/main/java/makeus/cmc/malmo/adaptor/in/web/controller/ChatRoomController.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/in/web/controller/ChatRoomController.java
@@ -45,6 +45,7 @@ public class ChatRoomController {
             content = @Content(schema = @Schema(implementation = SwaggerResponses.GetChatRoomSummaryResponse.class))
     )
     @ApiCommonResponses.RequireAuth
+    @ApiCommonResponses.OnlyOwner
     @GetMapping("/{chatRoomId}/summary")
     public BaseResponse<GetChatRoomSummaryUseCase.GetChatRoomSummaryResponse> getCurrentChatRoom(
             @AuthenticationPrincipal User user, @PathVariable Long chatRoomId) {
@@ -68,7 +69,7 @@ public class ChatRoomController {
     )
     @ApiCommonResponses.RequireAuth
     @GetMapping
-    public BaseResponse<BaseListResponse<GetChatRoomListUseCase.GetChatRoomResponse>> getCurrentChatRoom(
+    public BaseResponse<BaseListResponse<GetChatRoomListUseCase.GetChatRoomResponse>> getChatRoomList(
             @RequestParam(value = "page", defaultValue = "0") int page,
             @RequestParam(value = "size", defaultValue = "10") int size,
             @RequestParam(value = "keyword", defaultValue = "") String keyword,
@@ -94,8 +95,9 @@ public class ChatRoomController {
             content = @Content(schema = @Schema(implementation = SwaggerResponses.ChatMessageListSuccessResponse.class))
     )
     @ApiCommonResponses.RequireAuth
+    @ApiCommonResponses.OnlyOwner
     @GetMapping("/{chatRoomId}/messages")
-    public BaseResponse<BaseListResponse<GetChatRoomMessagesUseCase.ChatRoomMessageDto>> getCurrentChatRoomMessages(
+    public BaseResponse<BaseListResponse<GetChatRoomMessagesUseCase.ChatRoomMessageDto>> getChatRoomMessages(
             @RequestParam(value = "page", defaultValue = "0") int page,
             @RequestParam(value = "size", defaultValue = "10") int size,
             @AuthenticationPrincipal User user, @PathVariable Long chatRoomId) {
@@ -120,8 +122,9 @@ public class ChatRoomController {
             content = @Content(schema = @Schema(implementation = SwaggerResponses.ChatRoomDeleteSuccessResponse.class))
     )
     @ApiCommonResponses.RequireAuth
+    @ApiCommonResponses.OnlyOwner
     @DeleteMapping
-    public BaseResponse getCurrentChatRoom(
+    public BaseResponse deleteChatRooms(
             @AuthenticationPrincipal User user, @RequestBody DeleteChatRoomRequestDto requestDto) {
         DeleteChatRoomUseCase.DeleteChatRoomsCommand command = DeleteChatRoomUseCase.DeleteChatRoomsCommand.builder()
                 .userId(Long.valueOf(user.getUsername()))

--- a/src/main/java/makeus/cmc/malmo/adaptor/in/web/docs/ApiCommonResponses.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/in/web/docs/ApiCommonResponses.java
@@ -161,4 +161,19 @@ public class ApiCommonResponses {
     })
     public @interface OnlyTested {
     }
+
+    /**
+     * 리소스 주인만 접근 가능
+     */
+    @Target({ElementType.METHOD})
+    @Retention(RetentionPolicy.RUNTIME)
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "403",
+                    description = "해당 리소스의 소유자가 아닙니다.",
+                    content = @Content(schema = @Schema(implementation = SwaggerErrorResponse.class))
+            )
+    })
+    public @interface OnlyOwner {
+    }
 }

--- a/src/main/java/makeus/cmc/malmo/adaptor/in/web/docs/SwaggerResponses.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/in/web/docs/SwaggerResponses.java
@@ -180,6 +180,11 @@ public class SwaggerResponses {
     public static class ChatRoomListSuccessResponse extends BaseSwaggerResponse<BaseListSwaggerResponse<GetChatRoomListResponse>> {
     }
 
+    @Getter
+    @Schema(description = "채팅방 삭제 성공 응답")
+    public static class ChatRoomDeleteSuccessResponse extends BaseSwaggerResponse {
+    }
+
     // 데이터 클래스들
     @Getter
     @Schema(description = "로그인 응답 데이터")

--- a/src/main/java/makeus/cmc/malmo/adaptor/in/web/docs/SwaggerResponses.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/in/web/docs/SwaggerResponses.java
@@ -175,6 +175,11 @@ public class SwaggerResponses {
     public static class GetChatRoomSummaryResponse extends BaseSwaggerResponse<GetChatRoomSummaryData> {
     }
 
+    @Getter
+    @Schema(description = "채팅방 리스트 조회 성공 응답")
+    public static class ChatRoomListSuccessResponse extends BaseSwaggerResponse<BaseListSwaggerResponse<GetChatRoomListResponse>> {
+    }
+
     // 데이터 클래스들
     @Getter
     @Schema(description = "로그인 응답 데이터")
@@ -472,5 +477,20 @@ public class SwaggerResponses {
         private String secondSummary;
         @Schema(description = "채팅방 해결 제안", example = "남자친구가 방어적이지 않도록, 대화 전 일정한 거리를 두고 대화하길 추천함. 대화 목적이 관계 개선임을 먼저 짚고, 자기방어형 말하기에는 상대의 의도를 인정하면서도 감정을 정리해 전하는 것이 중요함. 예: “네가 그런 의도가 아니었다는 건 알지만, 나는 그 말에 힘들었어.")
         private String thirdSummary;
+    }
+
+    @Getter
+    @Schema(description = "채팅 리스트 조회 완료 응답 데이터")
+    public static class GetChatRoomListResponse {
+        @Schema(description = "채팅방의 ID", example = "1")
+        private Long chatRoomId;
+        @Schema(description = "채팅방 전체 요약", example = "회피형 남자친구의 연락두절 문제")
+        private String totalSummary;
+        @Schema(description = "채팅방 상황 키워드", example = "연락 회피")
+        private String situationKeyword;
+        @Schema(description = "채팅방 해결 키워드", example = "완충 표현")
+        private String solutionKeyword;
+        @Schema(description = "채팅방 생성 시간", example = "2025-07-20T10:15:30")
+        private LocalDateTime createdAt;
     }
 }

--- a/src/main/java/makeus/cmc/malmo/adaptor/out/OpenAiApiClient.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/out/OpenAiApiClient.java
@@ -104,7 +104,8 @@ public class OpenAiApiClient implements RequestChatApiPort {
 
     @Override
     public String requestTotalSummary(List<Map<String, String>> messages) {
-        Map<String, Object> body = createBody(messages);
+        // OpenAI API에 요청할 때 응답 형식을 JSON으로 지정
+        Map<String, Object> body = createBodyForJsonResponse(messages);
         Request request = createRequest(body);
 
         try (Response response = client.newCall(request).execute()) {
@@ -186,6 +187,16 @@ public class OpenAiApiClient implements RequestChatApiPort {
     private Map<String, Object> createBody(List<Map<String, String>> messages) {
         return Map.of(
                 "model", GPT_VERSION,
+                "messages", messages,
+                "temperature", GPT_TEMPERATURE,
+                "stream", false
+        );
+    }
+
+    private Map<String, Object> createBodyForJsonResponse(List<Map<String, String>> messages) {
+        return Map.of(
+                "model", GPT_VERSION,
+                "response_format", Map.of("type", "json_object"),
                 "messages", messages,
                 "temperature", GPT_TEMPERATURE,
                 "stream", false

--- a/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/ChatRoomPersistenceAdapter.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/ChatRoomPersistenceAdapter.java
@@ -7,10 +7,7 @@ import makeus.cmc.malmo.adaptor.out.persistence.mapper.ChatMessageMapper;
 import makeus.cmc.malmo.adaptor.out.persistence.mapper.ChatRoomMapper;
 import makeus.cmc.malmo.adaptor.out.persistence.repository.ChatMessageRepository;
 import makeus.cmc.malmo.adaptor.out.persistence.repository.ChatRoomRepository;
-import makeus.cmc.malmo.application.port.out.LoadChatRoomPort;
-import makeus.cmc.malmo.application.port.out.LoadMessagesPort;
-import makeus.cmc.malmo.application.port.out.SaveChatMessagePort;
-import makeus.cmc.malmo.application.port.out.SaveChatRoomPort;
+import makeus.cmc.malmo.application.port.out.*;
 import makeus.cmc.malmo.domain.model.chat.ChatMessage;
 import makeus.cmc.malmo.domain.model.chat.ChatRoom;
 import makeus.cmc.malmo.domain.value.id.ChatRoomId;
@@ -23,7 +20,7 @@ import java.util.Optional;
 @Component
 @RequiredArgsConstructor
 public class ChatRoomPersistenceAdapter
-        implements LoadMessagesPort, SaveChatRoomPort, LoadChatRoomPort, SaveChatMessagePort{
+        implements LoadMessagesPort, SaveChatRoomPort, LoadChatRoomPort, SaveChatMessagePort, DeleteChatRoomPort {
 
     private final ChatRoomRepository chatRoomRepository;
     private final ChatMessageRepository chatMessageRepository;
@@ -86,5 +83,19 @@ public class ChatRoomPersistenceAdapter
                 .stream()
                 .map(chatRoomMapper::toDomain)
                 .toList();
+    }
+
+    @Override
+    public boolean isMemberOwnerOfChatRooms(MemberId memberId, List<ChatRoomId> chatRoomIds) {
+        return chatRoomRepository.isMemberOwnerOfChatRooms(
+                memberId.getValue(),
+                chatRoomIds.stream().map(ChatRoomId::getValue).toList());
+    }
+
+    @Override
+    public void deleteChatRooms(List<ChatRoomId> chatRoomIds) {
+        chatRoomRepository.deleteChatRooms(
+                chatRoomIds.stream().map(ChatRoomId::getValue).toList()
+        );
     }
 }

--- a/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/ChatRoomPersistenceAdapter.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/ChatRoomPersistenceAdapter.java
@@ -36,6 +36,11 @@ public class ChatRoomPersistenceAdapter
     }
 
     @Override
+    public List<ChatRoomMessageRepositoryDto> loadMessagesDtoAsc(ChatRoomId chatRoomId, int page, int size) {
+        return chatMessageRepository.loadCurrentMessagesDtoAsc(chatRoomId.getValue(), page, size);
+    }
+
+    @Override
     public List<ChatMessage> loadChatRoomMessagesByLevel(ChatRoomId chatRoomId, int level) {
         return chatMessageRepository.findByChatRoomIdAndLevel(chatRoomId.getValue(), level)
                 .stream()

--- a/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/ChatRoomPersistenceAdapter.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/ChatRoomPersistenceAdapter.java
@@ -74,4 +74,12 @@ public class ChatRoomPersistenceAdapter
         return chatRoomRepository.findPausedChatRoomByMemberEntityId(memberId.getValue())
                 .map(chatRoomMapper::toDomain);
     }
+
+    @Override
+    public List<ChatRoom> loadAliveChatRoomsByMemberId(MemberId memberId, String keyword, int page, int size) {
+        return chatRoomRepository.loadChatRoomListByMemberId(memberId.getValue(), keyword, page, size)
+                .stream()
+                .map(chatRoomMapper::toDomain)
+                .toList();
+    }
 }

--- a/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/entity/chat/ChatRoomEntity.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/entity/chat/ChatRoomEntity.java
@@ -34,4 +34,10 @@ public class ChatRoomEntity extends BaseTimeEntity {
 
     @Column(columnDefinition = "TEXT")
     private String totalSummary;
+
+    @Column(columnDefinition = "TEXT")
+    private String situationKeyword;
+
+    @Column(columnDefinition = "TEXT")
+    private String solutionKeyword;
 }

--- a/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/mapper/ChatRoomMapper.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/mapper/ChatRoomMapper.java
@@ -19,6 +19,8 @@ public class ChatRoomMapper {
                 entity.getLevel(),
                 entity.getLastMessageSentTime(),
                 entity.getTotalSummary(),
+                entity.getSituationKeyword(),
+                entity.getSolutionKeyword(),
                 entity.getCreatedAt(),
                 entity.getModifiedAt(),
                 entity.getDeletedAt()
@@ -37,6 +39,8 @@ public class ChatRoomMapper {
                 .lastMessageSentTime(domain.getLastMessageSentTime())
                 .level(domain.getLevel())
                 .totalSummary(domain.getTotalSummary())
+                .situationKeyword(domain.getSituationKeyword())
+                .solutionKeyword(domain.getSolutionKeyword())
                 .createdAt(domain.getCreatedAt())
                 .modifiedAt(domain.getModifiedAt())
                 .deletedAt(domain.getDeletedAt())

--- a/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/repository/ChatRoomRepository.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/repository/ChatRoomRepository.java
@@ -1,12 +1,13 @@
 package makeus.cmc.malmo.adaptor.out.persistence.repository;
 
 import makeus.cmc.malmo.adaptor.out.persistence.entity.chat.ChatRoomEntity;
+import makeus.cmc.malmo.adaptor.out.persistence.repository.custom.ChatRoomRepositoryCustom;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
-public interface ChatRoomRepository extends JpaRepository<ChatRoomEntity, Long> {
+public interface ChatRoomRepository extends JpaRepository<ChatRoomEntity, Long>, ChatRoomRepositoryCustom {
 
     @Query("select c from ChatRoomEntity c where c.memberEntityId.value = ?1 AND c.chatRoomState != 'DELETED' AND c.chatRoomState != 'COMPLETED'")
     Optional<ChatRoomEntity> findCurrentChatRoomByMemberEntityId(Long memberId);

--- a/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/repository/custom/ChatMessageRepositoryCustom.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/repository/custom/ChatMessageRepositoryCustom.java
@@ -6,4 +6,5 @@ import java.util.List;
 
 public interface ChatMessageRepositoryCustom {
     List<LoadMessagesPort.ChatRoomMessageRepositoryDto> loadCurrentMessagesDto(Long chatRoomId, int page, int size);
+    List<LoadMessagesPort.ChatRoomMessageRepositoryDto> loadCurrentMessagesDtoAsc(Long chatRoomId, int page, int size);
 }

--- a/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/repository/custom/ChatMessageRepositoryCustomImpl.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/repository/custom/ChatMessageRepositoryCustomImpl.java
@@ -35,4 +35,24 @@ public class ChatMessageRepositoryCustomImpl implements ChatMessageRepositoryCus
                 .limit(size)
                 .fetch();
     }
+
+    @Override
+    public List<LoadMessagesPort.ChatRoomMessageRepositoryDto> loadCurrentMessagesDtoAsc(Long chatRoomId, int page, int size) {
+        return queryFactory.select(Projections.constructor(LoadMessagesPort.ChatRoomMessageRepositoryDto.class,
+                        chatMessageEntity.id,
+                        chatMessageEntity.senderType,
+                        chatMessageEntity.content,
+                        chatMessageEntity.createdAt,
+                        savedChatMessageEntity.isNotNull()
+                ))
+                .from(chatMessageEntity)
+                .leftJoin(savedChatMessageEntity)
+                .on(savedChatMessageEntity.chatMessageEntityId.value.eq(chatMessageEntity.id)
+                        .and(savedChatMessageEntity.savedChatMessageState.eq(SavedChatMessageState.ALIVE)))
+                .where(chatMessageEntity.chatRoomEntityId.value.eq(chatRoomId))
+                .orderBy(chatMessageEntity.createdAt.asc())
+                .offset((long) page * size)
+                .limit(size)
+                .fetch();
+    }
 }

--- a/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/repository/custom/ChatRoomRepositoryCustom.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/repository/custom/ChatRoomRepositoryCustom.java
@@ -1,0 +1,11 @@
+package makeus.cmc.malmo.adaptor.out.persistence.repository.custom;
+
+import makeus.cmc.malmo.adaptor.out.persistence.entity.chat.ChatRoomEntity;
+import makeus.cmc.malmo.application.port.out.LoadMessagesPort;
+import makeus.cmc.malmo.domain.model.chat.ChatRoom;
+
+import java.util.List;
+
+public interface ChatRoomRepositoryCustom {
+    List<ChatRoomEntity> loadChatRoomListByMemberId(Long memberId, String keyword, int page, int size);
+}

--- a/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/repository/custom/ChatRoomRepositoryCustom.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/repository/custom/ChatRoomRepositoryCustom.java
@@ -8,4 +8,8 @@ import java.util.List;
 
 public interface ChatRoomRepositoryCustom {
     List<ChatRoomEntity> loadChatRoomListByMemberId(Long memberId, String keyword, int page, int size);
+
+    boolean isMemberOwnerOfChatRooms(Long memberId, List<Long> chatRoomIds);
+
+    void deleteChatRooms(List<Long> chatRoomIds);
 }

--- a/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/repository/custom/ChatRoomRepositoryCustomImpl.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/repository/custom/ChatRoomRepositoryCustomImpl.java
@@ -30,4 +30,24 @@ public class ChatRoomRepositoryCustomImpl implements ChatRoomRepositoryCustom{
                 .limit(size)
                 .fetch();
     }
+
+    @Override
+    public boolean isMemberOwnerOfChatRooms(Long memberId, List<Long> chatRoomIds) {
+        Long count = queryFactory.select(chatRoomEntity.count())
+                .from(chatRoomEntity)
+                .where(chatRoomEntity.memberEntityId.value.eq(memberId)
+                        .and(chatRoomEntity.chatRoomState.eq(ChatRoomState.COMPLETED))
+                        .and(chatRoomEntity.id.in(chatRoomIds)))
+                .fetchOne();
+
+        return count != null && count == chatRoomIds.size();
+    }
+
+    @Override
+    public void deleteChatRooms(List<Long> chatRoomIds) {
+        queryFactory.update(chatRoomEntity)
+                .set(chatRoomEntity.chatRoomState, ChatRoomState.DELETED)
+                .where(chatRoomEntity.id.in(chatRoomIds))
+                .execute();
+    }
 }

--- a/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/repository/custom/ChatRoomRepositoryCustomImpl.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/repository/custom/ChatRoomRepositoryCustomImpl.java
@@ -1,0 +1,33 @@
+package makeus.cmc.malmo.adaptor.out.persistence.repository.custom;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import makeus.cmc.malmo.adaptor.out.persistence.entity.chat.ChatRoomEntity;
+import makeus.cmc.malmo.domain.value.state.ChatRoomState;
+
+import java.util.List;
+
+import static makeus.cmc.malmo.adaptor.out.persistence.entity.chat.QChatRoomEntity.chatRoomEntity;
+
+@RequiredArgsConstructor
+public class ChatRoomRepositoryCustomImpl implements ChatRoomRepositoryCustom{
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<ChatRoomEntity> loadChatRoomListByMemberId(Long memberId, String keyword, int page, int size) {
+        BooleanExpression keywordCondition = keyword == null || keyword.isEmpty()
+                ? null
+                : chatRoomEntity.totalSummary.containsIgnoreCase(keyword);
+
+        return queryFactory.selectFrom(chatRoomEntity)
+                .where(chatRoomEntity.memberEntityId.value.eq(memberId)
+                        .and(chatRoomEntity.chatRoomState.eq(ChatRoomState.COMPLETED))
+                        .and(keywordCondition))
+                .orderBy(chatRoomEntity.createdAt.desc())
+                .offset((long) page * size)
+                .limit(size)
+                .fetch();
+    }
+}

--- a/src/main/java/makeus/cmc/malmo/application/port/in/DeleteChatRoomUseCase.java
+++ b/src/main/java/makeus/cmc/malmo/application/port/in/DeleteChatRoomUseCase.java
@@ -1,0 +1,18 @@
+package makeus.cmc.malmo.application.port.in;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+
+public interface DeleteChatRoomUseCase {
+
+    void deleteChatRooms(DeleteChatRoomsCommand command);
+
+    @Data
+    @Builder
+    class DeleteChatRoomsCommand {
+        private Long userId;
+        private List<Long> chatRoomIdList;
+    }
+}

--- a/src/main/java/makeus/cmc/malmo/application/port/in/GetChatRoomListUseCase.java
+++ b/src/main/java/makeus/cmc/malmo/application/port/in/GetChatRoomListUseCase.java
@@ -1,0 +1,37 @@
+package makeus.cmc.malmo.application.port.in;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface GetChatRoomListUseCase {
+
+    GetChatRoomListResponse getChatRoomList(GetChatRoomListCommand command);
+
+    @Data
+    @Builder
+    class GetChatRoomListCommand {
+        private Long userId;
+        private String keyword;
+        private Integer page;
+        private Integer size;
+    }
+
+    @Data
+    @Builder
+    class GetChatRoomListResponse {
+        private List<GetChatRoomResponse> chatRoomList;
+    }
+
+    @Data
+    @Builder
+    class GetChatRoomResponse {
+        private Long chatRoomId;
+        private String totalSummary;
+        private String situationKeyword;
+        private String solutionKeyword;
+        private LocalDateTime createdAt;
+    }
+}

--- a/src/main/java/makeus/cmc/malmo/application/port/in/GetChatRoomMessagesUseCase.java
+++ b/src/main/java/makeus/cmc/malmo/application/port/in/GetChatRoomMessagesUseCase.java
@@ -1,0 +1,40 @@
+package makeus.cmc.malmo.application.port.in;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Data;
+import makeus.cmc.malmo.domain.value.type.SenderType;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface GetChatRoomMessagesUseCase {
+
+    GetCurrentChatRoomMessagesResponse getChatRoomMessages(GetChatRoomMessagesCommand command);
+
+    @Data
+    @Builder
+    class GetChatRoomMessagesCommand {
+        private Long userId;
+        private Long chatRoomId;
+        private int page;
+        private int size;
+    }
+
+    @Data
+    @Builder
+    class GetCurrentChatRoomMessagesResponse {
+        private List<ChatRoomMessageDto> messages;
+    }
+
+    @Data
+    @Builder
+    class ChatRoomMessageDto {
+        private Long messageId;
+        private SenderType senderType;
+        private String content;
+        private LocalDateTime createdAt;
+        @JsonProperty("isSaved")
+        private boolean isSaved;
+    }
+}

--- a/src/main/java/makeus/cmc/malmo/application/port/out/DeleteChatRoomPort.java
+++ b/src/main/java/makeus/cmc/malmo/application/port/out/DeleteChatRoomPort.java
@@ -1,0 +1,9 @@
+package makeus.cmc.malmo.application.port.out;
+
+import makeus.cmc.malmo.domain.value.id.ChatRoomId;
+
+import java.util.List;
+
+public interface DeleteChatRoomPort {
+    void deleteChatRooms(List<ChatRoomId> chatRoomIds);
+}

--- a/src/main/java/makeus/cmc/malmo/application/port/out/LoadChatRoomPort.java
+++ b/src/main/java/makeus/cmc/malmo/application/port/out/LoadChatRoomPort.java
@@ -4,10 +4,13 @@ import makeus.cmc.malmo.domain.model.chat.ChatRoom;
 import makeus.cmc.malmo.domain.value.id.ChatRoomId;
 import makeus.cmc.malmo.domain.value.id.MemberId;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface LoadChatRoomPort {
     Optional<ChatRoom> loadCurrentChatRoomByMemberId(MemberId memberId);
     Optional<ChatRoom> loadChatRoomById(ChatRoomId chatRoomId);
     Optional<ChatRoom> loadPausedChatRoomByMemberId(MemberId memberId);
+
+    List<ChatRoom> loadAliveChatRoomsByMemberId(MemberId memberId, String keyword, int page, int size);
 }

--- a/src/main/java/makeus/cmc/malmo/application/port/out/LoadChatRoomPort.java
+++ b/src/main/java/makeus/cmc/malmo/application/port/out/LoadChatRoomPort.java
@@ -13,4 +13,6 @@ public interface LoadChatRoomPort {
     Optional<ChatRoom> loadPausedChatRoomByMemberId(MemberId memberId);
 
     List<ChatRoom> loadAliveChatRoomsByMemberId(MemberId memberId, String keyword, int page, int size);
+
+    boolean isMemberOwnerOfChatRooms(MemberId memberId, List<ChatRoomId> chatRoomIds);
 }

--- a/src/main/java/makeus/cmc/malmo/application/port/out/LoadMessagesPort.java
+++ b/src/main/java/makeus/cmc/malmo/application/port/out/LoadMessagesPort.java
@@ -11,6 +11,7 @@ import java.util.List;
 
 public interface LoadMessagesPort {
     List<ChatRoomMessageRepositoryDto> loadMessagesDto(ChatRoomId chatRoomId, int page, int size);
+    List<ChatRoomMessageRepositoryDto> loadMessagesDtoAsc(ChatRoomId chatRoomId, int page, int size);
     List<ChatMessage> loadChatRoomMessagesByLevel(ChatRoomId chatRoomId, int level);
 
     @Data

--- a/src/main/java/makeus/cmc/malmo/application/service/ChatRoomService.java
+++ b/src/main/java/makeus/cmc/malmo/application/service/ChatRoomService.java
@@ -1,10 +1,7 @@
 package makeus.cmc.malmo.application.service;
 
 import lombok.RequiredArgsConstructor;
-import makeus.cmc.malmo.application.port.in.GetChatRoomListUseCase;
-import makeus.cmc.malmo.application.port.in.GetChatRoomMessagesUseCase;
-import makeus.cmc.malmo.application.port.in.GetChatRoomSummaryUseCase;
-import makeus.cmc.malmo.application.port.in.GetCurrentChatRoomMessagesUseCase;
+import makeus.cmc.malmo.application.port.in.*;
 import makeus.cmc.malmo.application.port.out.LoadMessagesPort;
 import makeus.cmc.malmo.domain.model.chat.ChatMessageSummary;
 import makeus.cmc.malmo.domain.model.chat.ChatRoom;
@@ -21,7 +18,8 @@ import java.util.Objects;
 @RequiredArgsConstructor
 @Service
 public class ChatRoomService
-        implements GetChatRoomSummaryUseCase, GetChatRoomListUseCase, GetChatRoomMessagesUseCase {
+        implements GetChatRoomSummaryUseCase, GetChatRoomListUseCase,
+        GetChatRoomMessagesUseCase, DeleteChatRoomUseCase {
 
     private final ChatRoomDomainService chatRoomDomainService;
     private final ChatMessagesDomainService chatMessagesDomainService;
@@ -93,5 +91,17 @@ public class ChatRoomService
         return GetCurrentChatRoomMessagesResponse.builder()
                 .messages(list)
                 .build();
+    }
+
+    @Override
+    public void deleteChatRooms(DeleteChatRoomsCommand command) {
+        // 모든 채팅방이 멤버 소유인지 검증
+        chatRoomDomainService.validateChatRoomsOwnership(
+                MemberId.of(command.getUserId()),
+                command.getChatRoomIdList().stream().map(ChatRoomId::of).toList());
+
+        chatRoomDomainService.deleteChatRooms(
+                command.getChatRoomIdList().stream().map(ChatRoomId::of).toList()
+        );
     }
 }

--- a/src/main/java/makeus/cmc/malmo/application/service/ChatStreamProcessor.java
+++ b/src/main/java/makeus/cmc/malmo/application/service/ChatStreamProcessor.java
@@ -1,5 +1,10 @@
 package makeus.cmc.malmo.application.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import makeus.cmc.malmo.application.port.out.RequestChatApiPort;
@@ -30,6 +35,8 @@ public class ChatStreamProcessor {
     private final ChatRoomDomainService chatRoomDomainService;
     private final SendSseEventPort sendSseEventPort;
     private final SaveChatMessageSummaryPort saveChatMessageSummaryPort;
+
+    private final ObjectMapper objectMapper;
 
     public void requestApiStream(MemberId memberId,
                                  boolean isMemberCoupled,
@@ -125,7 +132,25 @@ public class ChatStreamProcessor {
 
         String summary = requestChatApiPort.requestTotalSummary(messages);
 
-        chatRoomDomainService.updateChatRoomSummary(chatRoom, summary);
+        try {
+            CounselingSummary counselingSummary = objectMapper.readValue(summary, CounselingSummary.class);
+
+            chatRoomDomainService.updateChatRoomSummary(chatRoom,
+                    counselingSummary.totalSummary,
+                    counselingSummary.situationKeyword,
+                    counselingSummary.solutionKeyword);
+        } catch (JsonProcessingException e) {
+            log.error("Failed to parse summary JSON: {}", summary, e);
+        }
+    }
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class CounselingSummary {
+        private String totalSummary;
+        private String situationKeyword;
+        private String solutionKeyword;
     }
 
     private void saveAiMessage(MemberId memberId, ChatRoomId chatRoomId, int level, String fullAnswer) {

--- a/src/main/java/makeus/cmc/malmo/application/service/ChatStreamProcessor.java
+++ b/src/main/java/makeus/cmc/malmo/application/service/ChatStreamProcessor.java
@@ -140,6 +140,7 @@ public class ChatStreamProcessor {
                     counselingSummary.situationKeyword,
                     counselingSummary.solutionKeyword);
         } catch (JsonProcessingException e) {
+            // TODO: 에러 처리 로직 추가
             log.error("Failed to parse summary JSON: {}", summary, e);
         }
     }

--- a/src/main/java/makeus/cmc/malmo/domain/exception/MemberAccessDeniedException.java
+++ b/src/main/java/makeus/cmc/malmo/domain/exception/MemberAccessDeniedException.java
@@ -1,0 +1,11 @@
+package makeus.cmc.malmo.domain.exception;
+
+public class MemberAccessDeniedException extends RuntimeException {
+    public MemberAccessDeniedException() {
+        super("리소스 접근 권한이 없습니다.");
+    }
+
+    public MemberAccessDeniedException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/makeus/cmc/malmo/domain/model/chat/ChatRoom.java
+++ b/src/main/java/makeus/cmc/malmo/domain/model/chat/ChatRoom.java
@@ -19,6 +19,8 @@ public class ChatRoom {
     private int level;
     private LocalDateTime lastMessageSentTime;
     private String totalSummary;
+    private String situationKeyword;
+    private String solutionKeyword;
 
     // BaseTimeEntity fields
     private LocalDateTime createdAt;
@@ -35,7 +37,8 @@ public class ChatRoom {
     }
 
     public static ChatRoom from(Long id, MemberId memberId, ChatRoomState chatRoomState,
-                                int level, LocalDateTime lastMessageSentTime, String totalSummary,
+                                int level, LocalDateTime lastMessageSentTime,
+                                String totalSummary, String situationKeyword, String solutionKeyword,
                                 LocalDateTime createdAt, LocalDateTime modifiedAt, LocalDateTime deletedAt) {
         return ChatRoom.builder()
                 .id(id)
@@ -44,6 +47,8 @@ public class ChatRoom {
                 .level(level)
                 .lastMessageSentTime(lastMessageSentTime)
                 .totalSummary(totalSummary)
+                .situationKeyword(situationKeyword)
+                .solutionKeyword(solutionKeyword)
                 .createdAt(createdAt)
                 .modifiedAt(modifiedAt)
                 .deletedAt(deletedAt)
@@ -67,8 +72,10 @@ public class ChatRoom {
         this.chatRoomState = ChatRoomState.ALIVE;
     }
 
-    public void updateChatRoomSummary(String summary) {
-        this.totalSummary = summary;
+    public void updateChatRoomSummary(String totalSummary, String situationKeyword, String solutionKeyword) {
+        this.totalSummary = totalSummary;
+        this.situationKeyword = situationKeyword;
+        this.solutionKeyword = solutionKeyword;
     }
 
     public void complete() {

--- a/src/main/java/makeus/cmc/malmo/domain/model/chat/ChatRoom.java
+++ b/src/main/java/makeus/cmc/malmo/domain/model/chat/ChatRoom.java
@@ -7,6 +7,7 @@ import makeus.cmc.malmo.domain.value.id.MemberId;
 import makeus.cmc.malmo.domain.value.state.ChatRoomState;
 
 import java.time.LocalDateTime;
+import java.util.Objects;
 
 import static makeus.cmc.malmo.domain.model.chat.ChatRoomConstant.INIT_CHATROOM_LEVEL;
 
@@ -84,5 +85,9 @@ public class ChatRoom {
 
     public boolean isChatRoomValid() {
         return this.chatRoomState == ChatRoomState.ALIVE || this.chatRoomState == ChatRoomState.BEFORE_INIT;
+    }
+
+    public boolean isOwner(MemberId memberId) {
+        return Objects.equals(this.memberId.getValue(), memberId.getValue());
     }
 }

--- a/src/main/java/makeus/cmc/malmo/domain/service/ChatMessagesDomainService.java
+++ b/src/main/java/makeus/cmc/malmo/domain/service/ChatMessagesDomainService.java
@@ -25,6 +25,10 @@ public class ChatMessagesDomainService {
         return loadMessagesPort.loadMessagesDto(chatRoomId, page, size);
     }
 
+    public List<LoadMessagesPort.ChatRoomMessageRepositoryDto> getChatMessagesDtoAsc(ChatRoomId chatRoomId, int page, int size) {
+        return loadMessagesPort.loadMessagesDtoAsc(chatRoomId, page, size);
+    }
+
     @Transactional
     public ChatMessage createUserTextMessage(ChatRoomId chatRoomId, int level, String content) {
         ChatMessage chatMessage = ChatMessage.createUserTextMessage(chatRoomId, level, content);

--- a/src/main/java/makeus/cmc/malmo/domain/service/ChatRoomDomainService.java
+++ b/src/main/java/makeus/cmc/malmo/domain/service/ChatRoomDomainService.java
@@ -3,6 +3,7 @@ package makeus.cmc.malmo.domain.service;
 import lombok.RequiredArgsConstructor;
 import makeus.cmc.malmo.application.port.out.*;
 import makeus.cmc.malmo.domain.exception.ChatRoomNotFoundException;
+import makeus.cmc.malmo.domain.exception.MemberAccessDeniedException;
 import makeus.cmc.malmo.domain.exception.MemberNotFoundException;
 import makeus.cmc.malmo.domain.exception.NotValidChatRoomException;
 import makeus.cmc.malmo.domain.model.chat.ChatMessage;
@@ -28,6 +29,17 @@ public class ChatRoomDomainService {
     private final SaveChatRoomPort saveChatRoomPort;
     private final SaveChatMessagePort saveChatMessagePort;
     private final LoadChatRoomMetadataPort loadChatRoomMetadataPort;
+
+    public void validateChatRoomOwnership(MemberId memberId, ChatRoomId chatRoomId) {
+        // 채팅방이 존재하는지 확인하고, 존재하지 않으면 예외 발생
+        ChatRoom chatRoom = loadChatRoomPort.loadChatRoomById(chatRoomId)
+                .orElseThrow(ChatRoomNotFoundException::new);
+
+        // 채팅방의 소유자와 요청한 멤버가 일치하는지 확인
+        if (!chatRoom.isOwner(memberId)) {
+            throw new MemberAccessDeniedException("채팅방에 접근할 권한이 없습니다.");
+        }
+    }
 
     public ChatRoom getCurrentChatRoomByMemberId(MemberId memberId) {
         // 현재 채팅방이 존재하는지 확인하고, 없으면 초기 메시지와 함께 새로 생성

--- a/src/main/java/makeus/cmc/malmo/domain/service/ChatRoomDomainService.java
+++ b/src/main/java/makeus/cmc/malmo/domain/service/ChatRoomDomainService.java
@@ -13,6 +13,8 @@ import makeus.cmc.malmo.domain.value.id.MemberId;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 import static makeus.cmc.malmo.domain.model.chat.ChatRoomConstant.INIT_CHATROOM_LEVEL;
 import static makeus.cmc.malmo.domain.model.chat.ChatRoomConstant.INIT_CHAT_MESSAGE;
 
@@ -63,6 +65,10 @@ public class ChatRoomDomainService {
 
     public ChatRoom getChatRoomById(ChatRoomId chatRoomId) {
         return loadChatRoomPort.loadChatRoomById(chatRoomId).orElseThrow(ChatRoomNotFoundException::new);
+    }
+
+    public List<ChatRoom> getCompletedChatRoomsByMemberId(MemberId memberId, String keyword, int page, int size) {
+        return loadChatRoomPort.loadAliveChatRoomsByMemberId(memberId, keyword, page, size);
     }
 
     @Transactional

--- a/src/main/java/makeus/cmc/malmo/domain/service/ChatRoomDomainService.java
+++ b/src/main/java/makeus/cmc/malmo/domain/service/ChatRoomDomainService.java
@@ -104,8 +104,8 @@ public class ChatRoomDomainService {
     }
 
     @Transactional
-    public void updateChatRoomSummary(ChatRoom chatRoom, String summary) {
-        chatRoom.updateChatRoomSummary(summary);
+    public void updateChatRoomSummary(ChatRoom chatRoom, String totalSummary, String situationKeyword, String solutionKeyword) {
+        chatRoom.updateChatRoomSummary(totalSummary, situationKeyword, solutionKeyword);
         saveChatRoom(chatRoom);
     }
 

--- a/src/main/java/makeus/cmc/malmo/domain/service/ChatRoomDomainService.java
+++ b/src/main/java/makeus/cmc/malmo/domain/service/ChatRoomDomainService.java
@@ -27,6 +27,7 @@ public class ChatRoomDomainService {
     private final LoadChatRoomPort loadChatRoomPort;
     private final LoadMemberPort loadMemberPort;
     private final SaveChatRoomPort saveChatRoomPort;
+    private final DeleteChatRoomPort deleteChatRoomPort;
     private final SaveChatMessagePort saveChatMessagePort;
     private final LoadChatRoomMetadataPort loadChatRoomMetadataPort;
 
@@ -37,6 +38,14 @@ public class ChatRoomDomainService {
 
         // 채팅방의 소유자와 요청한 멤버가 일치하는지 확인
         if (!chatRoom.isOwner(memberId)) {
+            throw new MemberAccessDeniedException("채팅방에 접근할 권한이 없습니다.");
+        }
+    }
+
+    public void validateChatRoomsOwnership(MemberId memberId, List<ChatRoomId> chatRoomIds) {
+        boolean valid = loadChatRoomPort.isMemberOwnerOfChatRooms(memberId, chatRoomIds);
+
+        if (!valid) {
             throw new MemberAccessDeniedException("채팅방에 접근할 권한이 없습니다.");
         }
     }
@@ -136,5 +145,10 @@ public class ChatRoomDomainService {
                                     saveChatRoomPort.saveChatRoom(chatRoom);
                                 }
                         );
+    }
+
+    @Transactional
+    public void deleteChatRooms(List<ChatRoomId> chatRoomIds) {
+        deleteChatRoomPort.deleteChatRooms(chatRoomIds);
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> - #MM-43

## 📝 작업 내용

> - 기존 채팅방 종료 시 실행되던 전체 요약 기능에서 JSON 응답을 통한 키워드 요약 기능을 추가
> - 채팅방 리스트 API를 검색 조회 가능하도록 구현
> - 채팅방의 채팅 리스트를 조회하는 API 구현
> - 채팅방 다건 삭제 API 구현
