### PR TITLE
오늘의 질문 API 구현

### DIFF
--- a/src/main/java/makeus/cmc/malmo/adaptor/in/exception/GlobalExceptionHandler.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/in/exception/GlobalExceptionHandler.java
@@ -6,7 +6,7 @@ import makeus.cmc.malmo.adaptor.out.oidc.exception.OidcIdTokenException;
 import makeus.cmc.malmo.adaptor.out.oidc.exception.RestApiException;
 import makeus.cmc.malmo.application.exception.InvalidRefreshTokenException;
 import makeus.cmc.malmo.application.exception.MemberNotTestedException;
-import makeus.cmc.malmo.domain.NotCoupleMemberException;
+import makeus.cmc.malmo.domain.exception.NotCoupleMemberException;
 import makeus.cmc.malmo.domain.exception.*;
 import org.hibernate.TypeMismatchException;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/makeus/cmc/malmo/adaptor/in/web/controller/QuestionController.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/in/web/controller/QuestionController.java
@@ -93,10 +93,10 @@ public class QuestionController {
     @GetMapping("/{coupleQuestionId}/answers")
     public BaseResponse<GetQuestionAnswerUseCase.AnswerResponseDto> getAnswers(
             @AuthenticationPrincipal User user,
-            @PathVariable String coupleQuestionId) {
+            @PathVariable Long coupleQuestionId) {
         GetQuestionAnswerUseCase.GetQuestionAnswerCommand command = GetQuestionAnswerUseCase.GetQuestionAnswerCommand.builder()
                 .userId(Long.valueOf(user.getUsername()))
-                .coupleQuestionId(Long.valueOf(coupleQuestionId))
+                .coupleQuestionId(coupleQuestionId)
                 .build();
 
         return BaseResponse.success(getQuestionAnswerUseCase.getQuestionAnswers(command));

--- a/src/main/java/makeus/cmc/malmo/adaptor/in/web/controller/QuestionController.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/in/web/controller/QuestionController.java
@@ -13,7 +13,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import makeus.cmc.malmo.adaptor.in.web.docs.ApiCommonResponses;
 import makeus.cmc.malmo.adaptor.in.web.docs.SwaggerResponses;
-import makeus.cmc.malmo.adaptor.in.web.dto.BaseListResponse;
 import makeus.cmc.malmo.adaptor.in.web.dto.BaseResponse;
 import makeus.cmc.malmo.application.port.in.GetQuestionUseCase;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -21,7 +20,6 @@ import org.springframework.security.core.userdetails.User;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
 @Tag(name = "오늘의 질문 API", description = "커플 오늘의 질문 API")
 @Slf4j
@@ -67,10 +65,15 @@ public class QuestionController {
     @ApiCommonResponses.OnlyCouple
     @ApiCommonResponses.RequireAuth
     @GetMapping("/{level}")
-    public BaseResponse<PastQuestionResponseDto> getQuestion(
+    public BaseResponse<GetQuestionUseCase.GetQuestionResponse> getQuestion(
             @AuthenticationPrincipal User user,
             @PathVariable int level) {
-        return BaseResponse.success(PastQuestionResponseDto.builder().build());
+        GetQuestionUseCase.GetQuestionCommand command = GetQuestionUseCase.GetQuestionCommand.builder()
+                .userId(Long.valueOf(user.getUsername()))
+                .level(level)
+                .build();
+
+        return BaseResponse.success(getQuestionUseCase.getQuestion(command));
     }
 
     @Operation(
@@ -123,16 +126,6 @@ public class QuestionController {
     @Builder
     public static class AnswerResponseDto {
         private Long coupleQuestionId;
-    }
-
-
-    @Data
-    @Builder
-    public static class PastQuestionResponseDto {
-        private Long coupleQuestionId;
-        private String title;
-        private String content;
-        private LocalDateTime createdAt;
     }
 
     @Data

--- a/src/main/java/makeus/cmc/malmo/adaptor/in/web/controller/QuestionController.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/in/web/controller/QuestionController.java
@@ -55,52 +55,7 @@ public class QuestionController {
     }
 
     @Operation(
-            summary = "🚧 [개발 전] 오늘의 질문 리스트 조회",
-            description = "여태까지 등록된 커플 오늘의 질문 리스트를 조회합니다. JWT 토큰이 필요합니다.",
-            security = @SecurityRequirement(name = "Bearer Authentication")
-    )
-    @ApiResponse(
-            responseCode = "200",
-            description = "질문 리스트 조회 성공",
-            content = @Content(schema = @Schema(implementation = SwaggerResponses.QuestionListSuccessResponse.class))
-    )
-    @ApiCommonResponses.OnlyCouple
-    @ApiCommonResponses.RequireAuth
-    @GetMapping
-    public BaseResponse<BaseListResponse<QuestionListResponseDto>> getQuestionList(
-            @AuthenticationPrincipal User user,
-            @RequestParam(required = false) Integer page,
-            @RequestParam(required = false) Integer size
-    ) {
-        return BaseListResponse.success(
-                List.of(QuestionListResponseDto.builder().build()),
-                page
-        );
-    }
-
-    @Operation(
-            summary = "🚧 [개발 전] 오늘의 질문 답변 등록",
-            description = "커플 오늘의 질문에 답변을 등록합니다. JWT 토큰이 필요합니다.",
-            security = @SecurityRequirement(name = "Bearer Authentication")
-    )
-    @ApiResponse(
-            responseCode = "200",
-            description = "질문 답변 등록 성공",
-            content = @Content(schema = @Schema(implementation = SwaggerResponses.AnswerSuccessResponse.class))
-    )
-    @ApiCommonResponses.OnlyCouple
-    @ApiCommonResponses.RequireAuth
-    @PostMapping("/answers/{coupleQuestionId}")
-    public BaseResponse<AnswerResponseDto> postAnswer(
-            @AuthenticationPrincipal User user,
-            @PathVariable Long coupleQuestionId,
-            @Valid @RequestBody AnswerRequestDto requestDto
-    ) {
-        return BaseResponse.success(AnswerResponseDto.builder().build());
-    }
-
-    @Operation(
-            summary = "🚧 [개발 전] 질문 내용 조회",
+            summary = "과거 질문 조회",
             description = "커플 오늘의 질문을 조회합니다. JWT 토큰이 필요합니다.",
             security = @SecurityRequirement(name = "Bearer Authentication")
     )
@@ -111,16 +66,37 @@ public class QuestionController {
     )
     @ApiCommonResponses.OnlyCouple
     @ApiCommonResponses.RequireAuth
-    @GetMapping("/{coupleQuestionId}")
+    @GetMapping("/{level}")
     public BaseResponse<PastQuestionResponseDto> getQuestion(
             @AuthenticationPrincipal User user,
-            @PathVariable String coupleQuestionId) {
+            @PathVariable int level) {
         return BaseResponse.success(PastQuestionResponseDto.builder().build());
     }
 
     @Operation(
-            summary = "🚧 [개발 전] 질문 답변 조회",
-            description = "커플 과거 질문 답변을 조회합니다. JWT 토큰이 필요합니다.",
+            summary = "오늘의 질문 답변 등록",
+            description = "커플 오늘의 질문에 답변을 등록합니다. JWT 토큰이 필요합니다.",
+            security = @SecurityRequirement(name = "Bearer Authentication")
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "질문 답변 등록 성공",
+            content = @Content(schema = @Schema(implementation = SwaggerResponses.AnswerSuccessResponse.class))
+    )
+    @ApiCommonResponses.OnlyCouple
+    @ApiCommonResponses.RequireAuth
+    @PostMapping("/{coupleQuestionId}/answers")
+    public BaseResponse<AnswerResponseDto> postAnswer(
+            @AuthenticationPrincipal User user,
+            @PathVariable Long coupleQuestionId,
+            @Valid @RequestBody AnswerRequestDto requestDto
+    ) {
+        return BaseResponse.success(AnswerResponseDto.builder().build());
+    }
+
+    @Operation(
+            summary = "질문 답변 조회",
+            description = "커플 질문 답변을 조회합니다. JWT 토큰이 필요합니다.",
             security = @SecurityRequirement(name = "Bearer Authentication")
     )
     @ApiResponse(
@@ -130,20 +106,11 @@ public class QuestionController {
     )
     @ApiCommonResponses.OnlyCouple
     @ApiCommonResponses.RequireAuth
-    @GetMapping("/answers/{coupleQuestionId}")
-    public BaseResponse<PastAnswerResponseDto> getAnswer(
+    @GetMapping("/{coupleQuestionId}/answers")
+    public BaseResponse<PastAnswerResponseDto> getAnswers(
             @AuthenticationPrincipal User user,
             @PathVariable String coupleQuestionId) {
         return BaseResponse.success(PastAnswerResponseDto.builder().build());
-    }
-
-    @Data
-    @Builder
-    public static class QuestionListResponseDto {
-        private Long coupleQuestionId;
-        private String title;
-        private String content;
-        private LocalDateTime createdAt;
     }
 
     @Data
@@ -155,8 +122,9 @@ public class QuestionController {
     @Data
     @Builder
     public static class AnswerResponseDto {
-        private Long memberAnswerId;
+        private Long coupleQuestionId;
     }
+
 
     @Data
     @Builder
@@ -179,6 +147,6 @@ public class QuestionController {
     public static class PastAnswerDto {
         private String nickname;
         private String answer;
-        private LocalDateTime createdAt;
+        private boolean updatable;
     }
 }

--- a/src/main/java/makeus/cmc/malmo/adaptor/in/web/controller/QuestionController.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/in/web/controller/QuestionController.java
@@ -30,7 +30,7 @@ import java.util.List;
 public class QuestionController {
 
     @Operation(
-            summary = "🚧 [개발 전] 오늘의 질문 조회",
+            summary = "오늘의 질문 조회",
             description = "커플 오늘의 질문을 조회합니다. JWT 토큰이 필요합니다.",
             security = @SecurityRequirement(name = "Bearer Authentication")
     )

--- a/src/main/java/makeus/cmc/malmo/adaptor/in/web/controller/QuestionController.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/in/web/controller/QuestionController.java
@@ -15,6 +15,7 @@ import makeus.cmc.malmo.adaptor.in.web.docs.ApiCommonResponses;
 import makeus.cmc.malmo.adaptor.in.web.docs.SwaggerResponses;
 import makeus.cmc.malmo.adaptor.in.web.dto.BaseListResponse;
 import makeus.cmc.malmo.adaptor.in.web.dto.BaseResponse;
+import makeus.cmc.malmo.application.port.in.GetQuestionUseCase;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.web.bind.annotation.*;
@@ -29,6 +30,8 @@ import java.util.List;
 @RequiredArgsConstructor
 public class QuestionController {
 
+    private final GetQuestionUseCase getQuestionUseCase;
+
     @Operation(
             summary = "오늘의 질문 조회",
             description = "커플 오늘의 질문을 조회합니다. JWT 토큰이 필요합니다.",
@@ -39,13 +42,16 @@ public class QuestionController {
             description = "오늘의 질문 조회 성공",
             content = @Content(schema = @Schema(implementation = SwaggerResponses.QuestionSuccessResponse.class))
     )
-    @ApiCommonResponses.OnlyCouple
     @ApiCommonResponses.RequireAuth
     @GetMapping("/today")
-    public BaseResponse<QuestionResponseDto> getTodayQuestion(
+    public BaseResponse<GetQuestionUseCase.GetQuestionResponse> getTodayQuestion(
             @AuthenticationPrincipal User user
     ) {
-        return BaseResponse.success(QuestionResponseDto.builder().build());
+        GetQuestionUseCase.GetTodayQuestionCommand command = GetQuestionUseCase.GetTodayQuestionCommand.builder()
+                .userId(Long.valueOf(user.getUsername()))
+                .build();
+
+        return BaseResponse.success(getQuestionUseCase.getTodayQuestion(command));
     }
 
     @Operation(
@@ -129,14 +135,6 @@ public class QuestionController {
             @AuthenticationPrincipal User user,
             @PathVariable String coupleQuestionId) {
         return BaseResponse.success(PastAnswerResponseDto.builder().build());
-    }
-
-    @Data
-    @Builder
-    public static class QuestionResponseDto {
-        private Long coupleQuestionId;
-        private String title;
-        private String content;
     }
 
     @Data

--- a/src/main/java/makeus/cmc/malmo/adaptor/in/web/docs/SwaggerResponses.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/in/web/docs/SwaggerResponses.java
@@ -124,11 +124,6 @@ public class SwaggerResponses {
     }
 
     @Getter
-    @Schema(description = "질문 리스트 조회 성공 응답")
-    public static class QuestionListSuccessResponse extends BaseSwaggerResponse<BaseListSwaggerResponse<QuestionListData>> {
-    }
-
-    @Getter
     @Schema(description = "질문 답변 등록 성공 응답")
     public static class AnswerSuccessResponse extends BaseSwaggerResponse<AnswerData> {
     }
@@ -365,8 +360,8 @@ public class SwaggerResponses {
     @Getter
     @Schema(description = "답변 등록 응답 데이터")
     public static class AnswerData {
-        @Schema(description = "멤버 답변 ID", example = "1")
-        private Long memberAnswerId;
+        @Schema(description = "답변이 달린 질문의 ID", example = "1")
+        private Long coupleQuestionId;
     }
 
     @Getter

--- a/src/main/java/makeus/cmc/malmo/adaptor/in/web/docs/SwaggerResponses.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/in/web/docs/SwaggerResponses.java
@@ -327,6 +327,9 @@ public class SwaggerResponses {
         @Schema(description = "커플 질문 ID", example = "1")
         private Long coupleQuestionId;
 
+        @Schema(description = "질문 단계", example = "3")
+        private int level;
+
         @Schema(description = "질문 제목", example = "오늘 하루 어땠나요?")
         private String title;
 
@@ -371,6 +374,9 @@ public class SwaggerResponses {
     public static class PastQuestionData {
         @Schema(description = "커플 질문 ID", example = "1")
         private Long coupleQuestionId;
+
+        @Schema(description = "질문 단계", example = "3")
+        private int level;
 
         @Schema(description = "질문 제목", example = "오늘 하루 어땠나요?")
         private String title;

--- a/src/main/java/makeus/cmc/malmo/adaptor/in/web/docs/SwaggerResponses.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/in/web/docs/SwaggerResponses.java
@@ -332,6 +332,15 @@ public class SwaggerResponses {
 
         @Schema(description = "질문 내용", example = "오늘 하루 중 가장 기억에 남는 순간은 무엇인가요?")
         private String content;
+
+        @Schema(description = "나의 답변 여부", example = "true")
+        private boolean meAnswered;
+
+        @Schema(description = "상대방 답변 여부", example = "false")
+        private boolean partnerAnswered;
+
+        @Schema(description = "생성일시", example = "2023-07-03T10:00:00")
+        private LocalDateTime createdAt;
     }
 
     @Getter
@@ -368,6 +377,12 @@ public class SwaggerResponses {
 
         @Schema(description = "질문 내용", example = "오늘 하루 중 가장 기억에 남는 순간은 무엇인가요?")
         private String content;
+
+        @Schema(description = "나의 답변 여부", example = "true")
+        private boolean meAnswered;
+
+        @Schema(description = "상대방 답변 여부", example = "false")
+        private boolean partnerAnswered;
 
         @Schema(description = "생성일시", example = "2023-07-03T10:00:00")
         private LocalDateTime createdAt;

--- a/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/CouplePersistenceAdapter.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/CouplePersistenceAdapter.java
@@ -3,16 +3,21 @@ package makeus.cmc.malmo.adaptor.out.persistence;
 import lombok.RequiredArgsConstructor;
 import makeus.cmc.malmo.adaptor.out.persistence.entity.couple.CoupleEntity;
 import makeus.cmc.malmo.adaptor.out.persistence.mapper.CoupleAggregateMapper;
+import makeus.cmc.malmo.adaptor.out.persistence.repository.CoupleMemberRepository;
 import makeus.cmc.malmo.adaptor.out.persistence.repository.CoupleRepository;
+import makeus.cmc.malmo.application.port.out.LoadCouplePort;
 import makeus.cmc.malmo.application.port.out.SaveCouplePort;
 import makeus.cmc.malmo.domain.model.couple.Couple;
+import makeus.cmc.malmo.domain.value.id.CoupleMemberId;
+import makeus.cmc.malmo.domain.value.id.MemberId;
 import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-public class CouplePersistenceAdapter implements SaveCouplePort {
+public class CouplePersistenceAdapter implements SaveCouplePort, LoadCouplePort {
 
     private final CoupleRepository coupleRepository;
+    private final CoupleMemberRepository coupleMemberRepository;
     private final CoupleAggregateMapper coupleAggregateMapper;
 
     @Override
@@ -20,5 +25,10 @@ public class CouplePersistenceAdapter implements SaveCouplePort {
         CoupleEntity entity = coupleAggregateMapper.toEntity(couple);
         CoupleEntity savedCoupleEntity = coupleRepository.save(entity);
         return coupleAggregateMapper.toDomain(savedCoupleEntity);
+    }
+
+    @Override
+    public CoupleMemberId loadCoupleMemberIdByMemberId(MemberId memberId) {
+        return CoupleMemberId.of(coupleMemberRepository.findCoupleMemberIdByMemberId(memberId.getValue()));
     }
 }

--- a/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/CouplePersistenceAdapter.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/CouplePersistenceAdapter.java
@@ -8,6 +8,7 @@ import makeus.cmc.malmo.adaptor.out.persistence.repository.CoupleRepository;
 import makeus.cmc.malmo.application.port.out.LoadCouplePort;
 import makeus.cmc.malmo.application.port.out.SaveCouplePort;
 import makeus.cmc.malmo.domain.model.couple.Couple;
+import makeus.cmc.malmo.domain.value.id.CoupleId;
 import makeus.cmc.malmo.domain.value.id.CoupleMemberId;
 import makeus.cmc.malmo.domain.value.id.MemberId;
 import org.springframework.stereotype.Component;
@@ -25,6 +26,11 @@ public class CouplePersistenceAdapter implements SaveCouplePort, LoadCouplePort 
         CoupleEntity entity = coupleAggregateMapper.toEntity(couple);
         CoupleEntity savedCoupleEntity = coupleRepository.save(entity);
         return coupleAggregateMapper.toDomain(savedCoupleEntity);
+    }
+
+    @Override
+    public CoupleId loadCoupleIdByMemberId(MemberId memberId) {
+        return CoupleId.of(coupleMemberRepository.findCoupleIdByMemberId(memberId.getValue()));
     }
 
     @Override

--- a/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/CoupleQuestionPersistenceAdapter.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/CoupleQuestionPersistenceAdapter.java
@@ -3,10 +3,17 @@ package makeus.cmc.malmo.adaptor.out.persistence;
 import lombok.Builder;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
+import makeus.cmc.malmo.adaptor.out.persistence.entity.question.CoupleQuestionEntity;
+import makeus.cmc.malmo.adaptor.out.persistence.entity.question.TempCoupleQuestionEntity;
 import makeus.cmc.malmo.adaptor.out.persistence.mapper.CoupleQuestionMapper;
+import makeus.cmc.malmo.adaptor.out.persistence.mapper.QuestionMapper;
 import makeus.cmc.malmo.adaptor.out.persistence.repository.CoupleQuestionRepository;
-import makeus.cmc.malmo.application.port.out.LoadCoupleQuestionPort;
+import makeus.cmc.malmo.adaptor.out.persistence.repository.QuestionRepository;
+import makeus.cmc.malmo.adaptor.out.persistence.repository.TempCoupleQuestionRepository;
+import makeus.cmc.malmo.application.port.out.*;
 import makeus.cmc.malmo.domain.model.question.CoupleQuestion;
+import makeus.cmc.malmo.domain.model.question.Question;
+import makeus.cmc.malmo.domain.model.question.TempCoupleQuestion;
 import makeus.cmc.malmo.domain.service.CoupleQuestionDomainService;
 import makeus.cmc.malmo.domain.value.id.CoupleId;
 import makeus.cmc.malmo.domain.value.id.CoupleQuestionId;
@@ -19,10 +26,16 @@ import java.util.Optional;
 
 @Component
 @RequiredArgsConstructor
-public class CoupleQuestionPersistenceAdapter implements LoadCoupleQuestionPort {
+public class CoupleQuestionPersistenceAdapter
+        implements LoadCoupleQuestionPort, LoadTempCoupleQuestionPort, LoadQuestionPort,
+        SaveCoupleQuestionPort, SaveTempCoupleQuestionPort {
 
     private final CoupleQuestionRepository coupleQuestionRepository;
+    private final TempCoupleQuestionRepository tempCoupleQuestionRepository;
+    private final QuestionRepository questionRepository;
+
     private final CoupleQuestionMapper coupleQuestionMapper;
+    private final QuestionMapper questionMapper;
 
     @Override
     public Optional<CoupleQuestion> loadMaxLevelCoupleQuestion(CoupleId coupleId) {
@@ -46,6 +59,32 @@ public class CoupleQuestionPersistenceAdapter implements LoadCoupleQuestionPort 
     public Optional<CoupleQuestion> loadCoupleQuestionById(CoupleQuestionId coupleQuestionId) {
         return coupleQuestionRepository.findById(coupleQuestionId.getValue())
                 .map(coupleQuestionMapper::toDomain);
+    }
+
+    @Override
+    public Optional<TempCoupleQuestion> loadTempCoupleQuestionByMemberId(MemberId memberId) {
+        return tempCoupleQuestionRepository.findByMemberId_Value(memberId.getValue())
+                .map(coupleQuestionMapper::toDomain);
+    }
+
+    @Override
+    public CoupleQuestion saveCoupleQuestion(CoupleQuestion coupleQuestion) {
+        CoupleQuestionEntity entity = coupleQuestionMapper.toEntity(coupleQuestion);
+        CoupleQuestionEntity savedEntity = coupleQuestionRepository.save(entity);
+        return coupleQuestionMapper.toDomain(savedEntity);
+    }
+
+    @Override
+    public TempCoupleQuestion saveTempCoupleQuestion(TempCoupleQuestion tempCoupleQuestion) {
+        TempCoupleQuestionEntity entity = coupleQuestionMapper.toEntity(tempCoupleQuestion);
+        TempCoupleQuestionEntity savedEntity = tempCoupleQuestionRepository.save(entity);
+        return coupleQuestionMapper.toDomain(savedEntity);
+    }
+
+    @Override
+    public Optional<Question> loadQuestionByLevel(int level) {
+        return questionRepository.findByLevel(level)
+                .map(questionMapper::toDomain);
     }
 
     @Data

--- a/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/CoupleQuestionPersistenceAdapter.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/CoupleQuestionPersistenceAdapter.java
@@ -101,21 +101,6 @@ public class CoupleQuestionPersistenceAdapter
         private boolean partnerAnswered;
         private LocalDateTime createdAt;
 
-        public static CoupleQuestionRepositoryDto from(CoupleQuestionDomainService.CoupleQuestionDto dto) {
-            return CoupleQuestionRepositoryDto.builder()
-                    .id(dto.getId())
-                    .title(dto.getTitle())
-                    .content(dto.getContent())
-                    .level(dto.getLevel())
-                    .coupleId(dto.getCoupleId().getValue())
-                    .coupleQuestionState(dto.getCoupleQuestionState())
-                    .bothAnsweredAt(dto.getBothAnsweredAt())
-                    .meAnswered(dto.isMeAnswered())
-                    .partnerAnswered(dto.isPartnerAnswered())
-                    .createdAt(dto.getCreatedAt())
-                    .build();
-        }
-
         public CoupleQuestionDomainService.CoupleQuestionDto toDto() {
             return CoupleQuestionDomainService.CoupleQuestionDto.builder()
                     .id(this.id)

--- a/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/CoupleQuestionPersistenceAdapter.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/CoupleQuestionPersistenceAdapter.java
@@ -1,5 +1,6 @@
 package makeus.cmc.malmo.adaptor.out.persistence;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
@@ -89,6 +90,7 @@ public class CoupleQuestionPersistenceAdapter
 
     @Data
     @Builder
+    @AllArgsConstructor
     public static class CoupleQuestionRepositoryDto {
         private Long id;
         private String title;

--- a/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/CoupleQuestionPersistenceAdapter.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/CoupleQuestionPersistenceAdapter.java
@@ -1,0 +1,95 @@
+package makeus.cmc.malmo.adaptor.out.persistence;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+import makeus.cmc.malmo.adaptor.out.persistence.mapper.CoupleQuestionMapper;
+import makeus.cmc.malmo.adaptor.out.persistence.repository.CoupleQuestionRepository;
+import makeus.cmc.malmo.application.port.out.LoadCoupleQuestionPort;
+import makeus.cmc.malmo.domain.model.question.CoupleQuestion;
+import makeus.cmc.malmo.domain.service.CoupleQuestionDomainService;
+import makeus.cmc.malmo.domain.value.id.CoupleId;
+import makeus.cmc.malmo.domain.value.id.CoupleQuestionId;
+import makeus.cmc.malmo.domain.value.id.MemberId;
+import makeus.cmc.malmo.domain.value.state.CoupleQuestionState;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class CoupleQuestionPersistenceAdapter implements LoadCoupleQuestionPort {
+
+    private final CoupleQuestionRepository coupleQuestionRepository;
+    private final CoupleQuestionMapper coupleQuestionMapper;
+
+    @Override
+    public Optional<CoupleQuestion> loadMaxLevelCoupleQuestion(CoupleId coupleId) {
+        return coupleQuestionRepository.findTopLevelQuestionByCoupleId(coupleId.getValue())
+                .map(coupleQuestionMapper::toDomain);
+    }
+
+    @Override
+    public Optional<CoupleQuestionDomainService.CoupleQuestionDto> getMaxLevelQuestionDto(MemberId memberId, CoupleId coupleId) {
+        return coupleQuestionRepository.findTopLevelQuestionDto(memberId.getValue(), coupleId.getValue())
+                .map(CoupleQuestionRepositoryDto::toDto);
+    }
+
+    @Override
+    public Optional<CoupleQuestionDomainService.CoupleQuestionDto> getCoupleQuestionDtoByLevel(MemberId memberId, CoupleId coupleId, int level) {
+        return coupleQuestionRepository.findQuestionDtoByLevel(memberId.getValue(), coupleId.getValue(), level)
+                .map(CoupleQuestionRepositoryDto::toDto);
+    }
+
+    @Override
+    public Optional<CoupleQuestion> loadCoupleQuestionById(CoupleQuestionId coupleQuestionId) {
+        return coupleQuestionRepository.findById(coupleQuestionId.getValue())
+                .map(coupleQuestionMapper::toDomain);
+    }
+
+    @Data
+    @Builder
+    public static class CoupleQuestionRepositoryDto {
+        private Long id;
+        private String title;
+        private String content;
+        private int level;
+        private Long coupleId;
+        private CoupleQuestionState coupleQuestionState;
+        private LocalDateTime bothAnsweredAt;
+        private boolean meAnswered;
+        private boolean partnerAnswered;
+        private LocalDateTime createdAt;
+
+        public static CoupleQuestionRepositoryDto from(CoupleQuestionDomainService.CoupleQuestionDto dto) {
+            return CoupleQuestionRepositoryDto.builder()
+                    .id(dto.getId())
+                    .title(dto.getTitle())
+                    .content(dto.getContent())
+                    .level(dto.getLevel())
+                    .coupleId(dto.getCoupleId().getValue())
+                    .coupleQuestionState(dto.getCoupleQuestionState())
+                    .bothAnsweredAt(dto.getBothAnsweredAt())
+                    .meAnswered(dto.isMeAnswered())
+                    .partnerAnswered(dto.isPartnerAnswered())
+                    .createdAt(dto.getCreatedAt())
+                    .build();
+        }
+
+        public CoupleQuestionDomainService.CoupleQuestionDto toDto() {
+            return CoupleQuestionDomainService.CoupleQuestionDto.builder()
+                    .id(this.id)
+                    .title(this.title)
+                    .content(this.content)
+                    .level(this.level)
+                    .coupleId(CoupleId.of(this.coupleId))
+                    .coupleQuestionState(this.coupleQuestionState)
+                    .bothAnsweredAt(this.bothAnsweredAt)
+                    .meAnswered(this.meAnswered)
+                    .partnerAnswered(this.partnerAnswered)
+                    .createdAt(this.createdAt)
+                    .build();
+        }
+    }
+}

--- a/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/MemberAnswerPersistenceAdapter.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/MemberAnswerPersistenceAdapter.java
@@ -1,5 +1,6 @@
 package makeus.cmc.malmo.adaptor.out.persistence;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
@@ -54,6 +55,7 @@ public class MemberAnswerPersistenceAdapter implements LoadMemberAnswerPort, Sav
 
     @Data
     @Builder
+    @AllArgsConstructor
     public static class AnswerRepositoryDto {
         private String nickname;
         private String answer;

--- a/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/MemberAnswerPersistenceAdapter.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/MemberAnswerPersistenceAdapter.java
@@ -1,0 +1,84 @@
+package makeus.cmc.malmo.adaptor.out.persistence;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+import makeus.cmc.malmo.adaptor.out.persistence.entity.question.MemberAnswerEntity;
+import makeus.cmc.malmo.adaptor.out.persistence.mapper.MemberAnswerMapper;
+import makeus.cmc.malmo.adaptor.out.persistence.repository.MemberAnswerRepository;
+import makeus.cmc.malmo.application.port.out.LoadMemberAnswerPort;
+import makeus.cmc.malmo.application.port.out.SaveMemberAnswerPort;
+import makeus.cmc.malmo.domain.model.question.MemberAnswer;
+import makeus.cmc.malmo.domain.service.CoupleQuestionDomainService;
+import makeus.cmc.malmo.domain.value.id.CoupleQuestionId;
+import makeus.cmc.malmo.domain.value.id.MemberId;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Component
+public class MemberAnswerPersistenceAdapter implements LoadMemberAnswerPort, SaveMemberAnswerPort {
+
+    private final MemberAnswerRepository memberAnswerRepository;
+    private final MemberAnswerMapper memberAnswerMapper;
+
+    @Override
+    public Optional<CoupleQuestionDomainService.MemberAnswersDto> getQuestionAnswers(MemberId memberId, CoupleQuestionId coupleQuestionId) {
+        return memberAnswerRepository.findAnswersDtoByCoupleQuestionId(memberId.getValue(), coupleQuestionId.getValue())
+                .map(AnswerRepositoryDto::toDto);
+    }
+
+    @Override
+    public Optional<MemberAnswer> getMemberAnswer(CoupleQuestionId coupleQuestionId, MemberId memberId) {
+        return memberAnswerRepository.findByCoupleQuestionIdAndCoupleMemberId(coupleQuestionId.getValue(), memberId.getValue())
+                .map(memberAnswerMapper::toDomain);
+    }
+
+    @Override
+    public boolean isMemberAnswered(CoupleQuestionId coupleQuestionId, MemberId memberId) {
+        return memberAnswerRepository.existsByCoupleQuestionIdAndMemberId(coupleQuestionId.getValue(), memberId.getValue());
+    }
+
+    @Override
+    public long countAnswers(CoupleQuestionId coupleQuestionId) {
+        return memberAnswerRepository.countByCoupleQuestionIdAndMemberId(coupleQuestionId.getValue());
+    }
+
+    @Override
+    public MemberAnswer saveMemberAnswer(MemberAnswer memberAnswer) {
+        MemberAnswerEntity entity = memberAnswerMapper.toEntity(memberAnswer);
+        MemberAnswerEntity savedEntity = memberAnswerRepository.save(entity);
+        return memberAnswerMapper.toDomain(savedEntity);
+    }
+
+    @Data
+    @Builder
+    public static class AnswerRepositoryDto {
+        private String nickname;
+        private String answer;
+        private boolean updatable;
+        private String partnerNickname;
+        private String partnerAnswer;
+        private boolean partnerUpdatable;
+
+        public CoupleQuestionDomainService.MemberAnswersDto toDto() {
+            return CoupleQuestionDomainService.MemberAnswersDto.builder()
+                    .me(
+                        CoupleQuestionDomainService.AnswerDto.builder()
+                            .nickname(nickname)
+                            .answer(answer)
+                            .updatable(updatable)
+                            .build()
+                    )
+                    .partner(
+                        CoupleQuestionDomainService.AnswerDto.builder()
+                            .nickname(partnerNickname)
+                            .answer(partnerAnswer)
+                            .updatable(partnerUpdatable)
+                            .build()
+                    )
+                    .build();
+        }
+    }
+}

--- a/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/entity/question/CoupleQuestionEntity.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/entity/question/CoupleQuestionEntity.java
@@ -7,7 +7,12 @@ import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 import makeus.cmc.malmo.adaptor.out.persistence.entity.BaseTimeEntity;
 import makeus.cmc.malmo.adaptor.out.persistence.entity.couple.CoupleEntity;
+import makeus.cmc.malmo.adaptor.out.persistence.entity.value.CoupleEntityId;
+import makeus.cmc.malmo.domain.model.question.Question;
+import makeus.cmc.malmo.domain.value.id.CoupleId;
 import makeus.cmc.malmo.domain.value.state.CoupleQuestionState;
+
+import java.time.LocalDateTime;
 
 @Getter
 @SuperBuilder
@@ -24,10 +29,11 @@ public class CoupleQuestionEntity extends BaseTimeEntity {
     @JoinColumn(name = "question_id")
     private QuestionEntity question;
 
-    @ManyToOne
-    @JoinColumn(name = "couple_id")
-    private CoupleEntity couple;
+    @Embedded
+    private CoupleEntityId coupleEntityId;
 
     @Enumerated(EnumType.STRING)
     private CoupleQuestionState coupleQuestionState;
+
+    private LocalDateTime bothAnsweredAt;
 }

--- a/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/entity/question/MemberAnswerEntity.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/entity/question/MemberAnswerEntity.java
@@ -7,6 +7,8 @@ import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 import makeus.cmc.malmo.adaptor.out.persistence.entity.BaseTimeEntity;
 import makeus.cmc.malmo.adaptor.out.persistence.entity.couple.CoupleMemberEntity;
+import makeus.cmc.malmo.adaptor.out.persistence.entity.value.CoupleMemberEntityId;
+import makeus.cmc.malmo.adaptor.out.persistence.entity.value.CoupleQuestionEntityId;
 import makeus.cmc.malmo.domain.value.state.MemberAnswerState;
 
 @Getter
@@ -20,13 +22,11 @@ public class MemberAnswerEntity extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
-    @JoinColumn(name = "couple_question_id")
-    private CoupleQuestionEntity coupleQuestion;
+    @Embedded
+    private CoupleQuestionEntityId coupleQuestionEntityId;
 
-    @ManyToOne
-    @JoinColumn(name = "couple_member_id")
-    private CoupleMemberEntity coupleMember;
+    @Embedded
+    private CoupleMemberEntityId coupleMemberEntityId;
 
     private String answer;
 

--- a/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/entity/question/QuestionEntity.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/entity/question/QuestionEntity.java
@@ -21,4 +21,6 @@ public class QuestionEntity extends BaseTimeEntity {
     private String title;
 
     private String content;
+
+    private int level;
 }

--- a/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/entity/question/TempCoupleQuestionEntity.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/entity/question/TempCoupleQuestionEntity.java
@@ -1,0 +1,36 @@
+package makeus.cmc.malmo.adaptor.out.persistence.entity.question;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import makeus.cmc.malmo.adaptor.out.persistence.entity.BaseTimeEntity;
+import makeus.cmc.malmo.adaptor.out.persistence.entity.value.MemberEntityId;
+import makeus.cmc.malmo.domain.model.question.Question;
+import makeus.cmc.malmo.domain.value.id.MemberId;
+
+import java.time.LocalDateTime;
+
+@Getter
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class TempCoupleQuestionEntity extends BaseTimeEntity {
+    @Column(name = "TempCoupleQuestionId")
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "question_id")
+    private QuestionEntity question;
+
+    @Embedded
+    private MemberEntityId memberId;
+
+    @Column(columnDefinition = "TEXT")
+    private String answer;
+
+}

--- a/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/entity/question/TempCoupleQuestionEntity.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/entity/question/TempCoupleQuestionEntity.java
@@ -10,6 +10,7 @@ import makeus.cmc.malmo.adaptor.out.persistence.entity.BaseTimeEntity;
 import makeus.cmc.malmo.adaptor.out.persistence.entity.value.MemberEntityId;
 import makeus.cmc.malmo.domain.model.question.Question;
 import makeus.cmc.malmo.domain.value.id.MemberId;
+import makeus.cmc.malmo.domain.value.state.CoupleQuestionState;
 
 import java.time.LocalDateTime;
 
@@ -32,5 +33,8 @@ public class TempCoupleQuestionEntity extends BaseTimeEntity {
 
     @Column(columnDefinition = "TEXT")
     private String answer;
+
+    @Enumerated(EnumType.STRING)
+    private CoupleQuestionState coupleQuestionState;
 
 }

--- a/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/entity/value/CoupleMemberEntityId.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/entity/value/CoupleMemberEntityId.java
@@ -1,0 +1,21 @@
+package makeus.cmc.malmo.adaptor.out.persistence.entity.value;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Embeddable
+public class CoupleMemberEntityId {
+    @Column(name = "couple_member_id")
+    Long value;
+
+    public static CoupleMemberEntityId of(Long value) {
+        return new CoupleMemberEntityId(value);
+    }
+}

--- a/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/entity/value/CoupleQuestionEntityId.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/entity/value/CoupleQuestionEntityId.java
@@ -1,0 +1,21 @@
+package makeus.cmc.malmo.adaptor.out.persistence.entity.value;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Embeddable
+public class CoupleQuestionEntityId {
+    @Column(name = "couple_question_id")
+    Long value;
+
+    public static CoupleQuestionEntityId of(Long value) {
+        return new CoupleQuestionEntityId(value);
+    }
+}

--- a/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/mapper/CoupleQuestionMapper.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/mapper/CoupleQuestionMapper.java
@@ -2,9 +2,12 @@ package makeus.cmc.malmo.adaptor.out.persistence.mapper;
 
 import lombok.RequiredArgsConstructor;
 import makeus.cmc.malmo.adaptor.out.persistence.entity.question.CoupleQuestionEntity;
+import makeus.cmc.malmo.adaptor.out.persistence.entity.question.TempCoupleQuestionEntity;
 import makeus.cmc.malmo.adaptor.out.persistence.entity.value.CoupleEntityId;
 import makeus.cmc.malmo.domain.model.question.CoupleQuestion;
+import makeus.cmc.malmo.domain.model.question.TempCoupleQuestion;
 import makeus.cmc.malmo.domain.value.id.CoupleId;
+import makeus.cmc.malmo.domain.value.id.MemberId;
 import org.springframework.stereotype.Component;
 
 @RequiredArgsConstructor
@@ -44,6 +47,38 @@ public class CoupleQuestionMapper {
                 .createdAt(coupleQuestion.getCreatedAt())
                 .modifiedAt(coupleQuestion.getModifiedAt())
                 .deletedAt(coupleQuestion.getDeletedAt())
+                .build();
+    }
+
+    public TempCoupleQuestion toDomain(TempCoupleQuestionEntity entity) {
+        if (entity == null) {
+            return null;
+        }
+        return TempCoupleQuestion.from(
+                entity.getId(),
+                questionMapper.toDomain(entity.getQuestion()),
+                entity.getMemberId() == null ? null
+                        : MemberId.of(entity.getMemberId().getValue()),
+                entity.getAnswer(),
+                entity.getCreatedAt(),
+                entity.getModifiedAt(),
+                entity.getDeletedAt()
+        );
+    }
+
+    public TempCoupleQuestionEntity toEntity(TempCoupleQuestion tempCoupleQuestion) {
+        if (tempCoupleQuestion == null) {
+            return null;
+        }
+        return TempCoupleQuestionEntity.builder()
+                .id(tempCoupleQuestion.getId())
+                .question(questionMapper.toEntity(tempCoupleQuestion.getQuestion()))
+                .memberId(tempCoupleQuestion.getMemberId() == null ? null
+                        : MemberId.of(tempCoupleQuestion.getMemberId().getValue()))
+                .answer(tempCoupleQuestion.getAnswer())
+                .createdAt(tempCoupleQuestion.getCreatedAt())
+                .modifiedAt(tempCoupleQuestion.getModifiedAt())
+                .deletedAt(tempCoupleQuestion.getDeletedAt())
                 .build();
     }
 }

--- a/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/mapper/CoupleQuestionMapper.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/mapper/CoupleQuestionMapper.java
@@ -1,0 +1,49 @@
+package makeus.cmc.malmo.adaptor.out.persistence.mapper;
+
+import lombok.RequiredArgsConstructor;
+import makeus.cmc.malmo.adaptor.out.persistence.entity.question.CoupleQuestionEntity;
+import makeus.cmc.malmo.adaptor.out.persistence.entity.value.CoupleEntityId;
+import makeus.cmc.malmo.domain.model.question.CoupleQuestion;
+import makeus.cmc.malmo.domain.value.id.CoupleId;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class CoupleQuestionMapper {
+
+    private final QuestionMapper questionMapper;
+
+    public CoupleQuestion toDomain(CoupleQuestionEntity entity) {
+        if (entity == null) {
+            return null;
+        }
+        return CoupleQuestion.from(
+                entity.getId(),
+                questionMapper.toDomain(entity.getQuestion()),
+                entity.getCoupleEntityId() == null ? null
+                        : CoupleId.of(entity.getCoupleEntityId().getValue()),
+                entity.getCoupleQuestionState(),
+                entity.getBothAnsweredAt(),
+                entity.getCreatedAt(),
+                entity.getModifiedAt(),
+                entity.getDeletedAt()
+        );
+    }
+
+    public CoupleQuestionEntity toEntity(CoupleQuestion coupleQuestion) {
+        if (coupleQuestion == null) {
+            return null;
+        }
+        return CoupleQuestionEntity.builder()
+                .id(coupleQuestion.getId())
+                .question(questionMapper.toEntity(coupleQuestion.getQuestion()))
+                .coupleEntityId(coupleQuestion.getCoupleId() == null ? null
+                        : CoupleEntityId.of(coupleQuestion.getCoupleId().getValue()))
+                .coupleQuestionState(coupleQuestion.getCoupleQuestionState())
+                .bothAnsweredAt(coupleQuestion.getBothAnsweredAt())
+                .createdAt(coupleQuestion.getCreatedAt())
+                .modifiedAt(coupleQuestion.getModifiedAt())
+                .deletedAt(coupleQuestion.getDeletedAt())
+                .build();
+    }
+}

--- a/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/mapper/CoupleQuestionMapper.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/mapper/CoupleQuestionMapper.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import makeus.cmc.malmo.adaptor.out.persistence.entity.question.CoupleQuestionEntity;
 import makeus.cmc.malmo.adaptor.out.persistence.entity.question.TempCoupleQuestionEntity;
 import makeus.cmc.malmo.adaptor.out.persistence.entity.value.CoupleEntityId;
+import makeus.cmc.malmo.adaptor.out.persistence.entity.value.MemberEntityId;
 import makeus.cmc.malmo.domain.model.question.CoupleQuestion;
 import makeus.cmc.malmo.domain.model.question.TempCoupleQuestion;
 import makeus.cmc.malmo.domain.value.id.CoupleId;
@@ -74,7 +75,7 @@ public class CoupleQuestionMapper {
                 .id(tempCoupleQuestion.getId())
                 .question(questionMapper.toEntity(tempCoupleQuestion.getQuestion()))
                 .memberId(tempCoupleQuestion.getMemberId() == null ? null
-                        : MemberId.of(tempCoupleQuestion.getMemberId().getValue()))
+                        : MemberEntityId.of(tempCoupleQuestion.getMemberId().getValue()))
                 .answer(tempCoupleQuestion.getAnswer())
                 .createdAt(tempCoupleQuestion.getCreatedAt())
                 .modifiedAt(tempCoupleQuestion.getModifiedAt())

--- a/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/mapper/CoupleQuestionMapper.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/mapper/CoupleQuestionMapper.java
@@ -61,6 +61,7 @@ public class CoupleQuestionMapper {
                 entity.getMemberId() == null ? null
                         : MemberId.of(entity.getMemberId().getValue()),
                 entity.getAnswer(),
+                entity.getCoupleQuestionState(),
                 entity.getCreatedAt(),
                 entity.getModifiedAt(),
                 entity.getDeletedAt()
@@ -77,6 +78,7 @@ public class CoupleQuestionMapper {
                 .memberId(tempCoupleQuestion.getMemberId() == null ? null
                         : MemberEntityId.of(tempCoupleQuestion.getMemberId().getValue()))
                 .answer(tempCoupleQuestion.getAnswer())
+                .coupleQuestionState(tempCoupleQuestion.getCoupleQuestionState())
                 .createdAt(tempCoupleQuestion.getCreatedAt())
                 .modifiedAt(tempCoupleQuestion.getModifiedAt())
                 .deletedAt(tempCoupleQuestion.getDeletedAt())

--- a/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/mapper/MemberAnswerMapper.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/mapper/MemberAnswerMapper.java
@@ -1,0 +1,43 @@
+package makeus.cmc.malmo.adaptor.out.persistence.mapper;
+
+import makeus.cmc.malmo.adaptor.out.persistence.entity.question.MemberAnswerEntity;
+import makeus.cmc.malmo.adaptor.out.persistence.entity.value.CoupleMemberEntityId;
+import makeus.cmc.malmo.adaptor.out.persistence.entity.value.CoupleQuestionEntityId;
+import makeus.cmc.malmo.domain.model.question.MemberAnswer;
+import makeus.cmc.malmo.domain.value.id.CoupleMemberId;
+import makeus.cmc.malmo.domain.value.id.CoupleQuestionId;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MemberAnswerMapper {
+
+    public MemberAnswer toDomain(MemberAnswerEntity memberAnswerEntity) {
+        return MemberAnswer.from(
+                memberAnswerEntity.getId(),
+                memberAnswerEntity.getCoupleQuestionEntityId() != null ?
+                        CoupleQuestionId.of(memberAnswerEntity.getCoupleQuestionEntityId().getValue()) : null,
+                memberAnswerEntity.getCoupleMemberEntityId() != null ?
+                        CoupleMemberId.of(memberAnswerEntity.getCoupleMemberEntityId().getValue()) : null,
+                memberAnswerEntity.getAnswer(),
+                memberAnswerEntity.getMemberAnswerState(),
+                memberAnswerEntity.getCreatedAt(),
+                memberAnswerEntity.getModifiedAt(),
+                memberAnswerEntity.getDeletedAt()
+        );
+    }
+
+    public MemberAnswerEntity toEntity(MemberAnswer memberAnswer) {
+        return MemberAnswerEntity.builder()
+                .id(memberAnswer.getId())
+                .coupleQuestionEntityId(memberAnswer.getCoupleQuestionId() != null ?
+                        CoupleQuestionEntityId.of(memberAnswer.getCoupleQuestionId().getValue()) : null)
+                .coupleMemberEntityId(memberAnswer.getCoupleMemberId() != null ?
+                        CoupleMemberEntityId.of(memberAnswer.getCoupleMemberId().getValue()) : null)
+                .answer(memberAnswer.getAnswer())
+                .memberAnswerState(memberAnswer.getMemberAnswerState())
+                .createdAt(memberAnswer.getCreatedAt())
+                .modifiedAt(memberAnswer.getModifiedAt())
+                .deletedAt(memberAnswer.getDeletedAt())
+                .build();
+    }
+}

--- a/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/mapper/QuestionMapper.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/mapper/QuestionMapper.java
@@ -1,0 +1,39 @@
+package makeus.cmc.malmo.adaptor.out.persistence.mapper;
+
+import makeus.cmc.malmo.adaptor.out.persistence.entity.question.QuestionEntity;
+import makeus.cmc.malmo.domain.model.question.Question;
+import org.springframework.stereotype.Component;
+
+@Component
+public class QuestionMapper {
+
+    public Question toDomain(QuestionEntity entity) {
+        if (entity == null) {
+            return null;
+        }
+        return Question.from(
+                entity.getId(),
+                entity.getTitle(),
+                entity.getContent(),
+                entity.getLevel(),
+                entity.getCreatedAt(),
+                entity.getModifiedAt(),
+                entity.getDeletedAt()
+        );
+    }
+
+    public QuestionEntity toEntity(Question question) {
+        if (question == null) {
+            return null;
+        }
+        return QuestionEntity.builder()
+                .id(question.getId())
+                .title(question.getTitle())
+                .content(question.getContent())
+                .level(question.getLevel())
+                .createdAt(question.getCreatedAt())
+                .modifiedAt(question.getModifiedAt())
+                .deletedAt(question.getDeletedAt())
+                .build();
+    }
+}

--- a/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/repository/CoupleMemberRepository.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/repository/CoupleMemberRepository.java
@@ -10,4 +10,7 @@ public interface CoupleMemberRepository extends JpaRepository<CoupleMemberEntity
 
     @Query("SELECT cm.id FROM CoupleMemberEntity cm WHERE cm.memberEntityId.value = :memberId AND cm.coupleMemberState = 'ALIVE'")
     Long findCoupleMemberIdByMemberId(Long memberId);
+
+    @Query("SELECT cm.coupleEntityId.value FROM CoupleMemberEntity cm WHERE cm.memberEntityId.value = :memberId AND cm.coupleMemberState = 'ALIVE'")
+    Long findCoupleIdByMemberId(Long memberId);
 }

--- a/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/repository/CoupleMemberRepository.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/repository/CoupleMemberRepository.java
@@ -1,0 +1,13 @@
+package makeus.cmc.malmo.adaptor.out.persistence.repository;
+
+import makeus.cmc.malmo.adaptor.out.persistence.entity.couple.CoupleMemberEntity;
+import makeus.cmc.malmo.adaptor.out.persistence.entity.question.MemberAnswerEntity;
+import makeus.cmc.malmo.adaptor.out.persistence.repository.custom.MemberAnswerRepositoryCustom;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface CoupleMemberRepository extends JpaRepository<CoupleMemberEntity, Long> {
+
+    @Query("SELECT cm.id FROM CoupleMemberEntity cm WHERE cm.memberEntityId.value = :memberId AND cm.coupleMemberState = 'ALIVE'")
+    Long findCoupleMemberIdByMemberId(Long memberId);
+}

--- a/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/repository/CoupleQuestionRepository.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/repository/CoupleQuestionRepository.java
@@ -1,0 +1,8 @@
+package makeus.cmc.malmo.adaptor.out.persistence.repository;
+
+import makeus.cmc.malmo.adaptor.out.persistence.entity.question.CoupleQuestionEntity;
+import makeus.cmc.malmo.adaptor.out.persistence.repository.custom.CoupleQuestionRepositoryCustom;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CoupleQuestionRepository extends JpaRepository<CoupleQuestionEntity, Long>, CoupleQuestionRepositoryCustom {
+}

--- a/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/repository/MemberAnswerRepository.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/repository/MemberAnswerRepository.java
@@ -1,0 +1,8 @@
+package makeus.cmc.malmo.adaptor.out.persistence.repository;
+
+import makeus.cmc.malmo.adaptor.out.persistence.entity.question.MemberAnswerEntity;
+import makeus.cmc.malmo.adaptor.out.persistence.repository.custom.MemberAnswerRepositoryCustom;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberAnswerRepository extends JpaRepository<MemberAnswerEntity, Long>, MemberAnswerRepositoryCustom {
+}

--- a/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/repository/QuestionRepository.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/repository/QuestionRepository.java
@@ -1,0 +1,14 @@
+package makeus.cmc.malmo.adaptor.out.persistence.repository;
+
+import makeus.cmc.malmo.adaptor.out.persistence.entity.question.CoupleQuestionEntity;
+import makeus.cmc.malmo.adaptor.out.persistence.entity.question.QuestionEntity;
+import makeus.cmc.malmo.adaptor.out.persistence.repository.custom.CoupleQuestionRepositoryCustom;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
+
+public interface QuestionRepository extends JpaRepository<QuestionEntity, Long> {
+
+    Optional<QuestionEntity> findByLevel(int level);
+}

--- a/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/repository/TempCoupleQuestionRepository.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/repository/TempCoupleQuestionRepository.java
@@ -1,0 +1,14 @@
+package makeus.cmc.malmo.adaptor.out.persistence.repository;
+
+import makeus.cmc.malmo.adaptor.out.persistence.entity.question.CoupleQuestionEntity;
+import makeus.cmc.malmo.adaptor.out.persistence.entity.question.TempCoupleQuestionEntity;
+import makeus.cmc.malmo.adaptor.out.persistence.repository.custom.CoupleQuestionRepositoryCustom;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
+
+public interface TempCoupleQuestionRepository extends JpaRepository<TempCoupleQuestionEntity, Long> {
+
+    Optional<TempCoupleQuestionEntity> findByMemberId_Value(Long memberId);
+}

--- a/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/repository/TempCoupleQuestionRepository.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/repository/TempCoupleQuestionRepository.java
@@ -10,5 +10,6 @@ import java.util.Optional;
 
 public interface TempCoupleQuestionRepository extends JpaRepository<TempCoupleQuestionEntity, Long> {
 
+    @Query("select t from TempCoupleQuestionEntity t where t.memberId.value = ?1 and t.coupleQuestionState = 'ALIVE'")
     Optional<TempCoupleQuestionEntity> findByMemberId_Value(Long memberId);
 }

--- a/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/repository/custom/CoupleQuestionRepositoryCustom.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/repository/custom/CoupleQuestionRepositoryCustom.java
@@ -1,0 +1,15 @@
+package makeus.cmc.malmo.adaptor.out.persistence.repository.custom;
+
+import makeus.cmc.malmo.adaptor.out.persistence.CoupleQuestionPersistenceAdapter;
+import makeus.cmc.malmo.adaptor.out.persistence.entity.question.CoupleQuestionEntity;
+
+import java.util.Optional;
+
+public interface CoupleQuestionRepositoryCustom {
+
+    Optional<CoupleQuestionEntity> findTopLevelQuestionByCoupleId(Long coupleId);
+
+    Optional<CoupleQuestionPersistenceAdapter.CoupleQuestionRepositoryDto> findTopLevelQuestionDto(Long memberId, Long coupleId);
+
+    Optional<CoupleQuestionPersistenceAdapter.CoupleQuestionRepositoryDto> findQuestionDtoByLevel(Long memberId, Long coupleId, int level);
+}

--- a/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/repository/custom/CoupleQuestionRepositoryCustomImpl.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/repository/custom/CoupleQuestionRepositoryCustomImpl.java
@@ -1,0 +1,104 @@
+package makeus.cmc.malmo.adaptor.out.persistence.repository.custom;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import makeus.cmc.malmo.adaptor.out.persistence.CoupleQuestionPersistenceAdapter;
+import makeus.cmc.malmo.adaptor.out.persistence.entity.question.CoupleQuestionEntity;
+
+import java.util.Optional;
+
+import static makeus.cmc.malmo.adaptor.out.persistence.entity.couple.QCoupleMemberEntity.coupleMemberEntity;
+import static makeus.cmc.malmo.adaptor.out.persistence.entity.member.QMemberEntity.memberEntity;
+import static makeus.cmc.malmo.adaptor.out.persistence.entity.question.QCoupleQuestionEntity.coupleQuestionEntity;
+import static makeus.cmc.malmo.adaptor.out.persistence.entity.question.QMemberAnswerEntity.memberAnswerEntity;
+
+@RequiredArgsConstructor
+public class CoupleQuestionRepositoryCustomImpl implements CoupleQuestionRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Optional<CoupleQuestionEntity> findTopLevelQuestionByCoupleId(Long coupleId) {
+        CoupleQuestionEntity entity = queryFactory
+                .selectFrom(coupleQuestionEntity)
+                .where(coupleQuestionEntity.coupleEntityId.value.eq(coupleId))
+                .orderBy(coupleQuestionEntity.question.level.asc())
+                .limit(1)
+                .fetchOne();
+
+        return Optional.ofNullable(entity);
+    }
+
+    @Override
+    public Optional<CoupleQuestionPersistenceAdapter.CoupleQuestionRepositoryDto> findTopLevelQuestionDto(Long memberId, Long coupleId) {
+        CoupleQuestionPersistenceAdapter.CoupleQuestionRepositoryDto dto = queryFactory
+                .select(Projections.constructor(CoupleQuestionPersistenceAdapter.CoupleQuestionRepositoryDto.class,
+                        coupleQuestionEntity.id,
+                        coupleQuestionEntity.question.title,
+                        coupleQuestionEntity.question.content,
+                        coupleQuestionEntity.question.level,
+                        coupleQuestionEntity.coupleEntityId.value,
+                        coupleQuestionEntity.coupleQuestionState,
+                        coupleQuestionEntity.bothAnsweredAt,
+                        JPAExpressions.selectOne()
+                                .from(memberAnswerEntity)
+                                .join(coupleMemberEntity)
+                                .on(memberAnswerEntity.coupleMemberEntityId.value.eq(coupleMemberEntity.id))
+                                .where(memberAnswerEntity.coupleQuestionEntityId.value.eq(coupleQuestionEntity.id)
+                                        .and(coupleMemberEntity.memberEntityId.value.eq(memberId)))
+                                .exists(),
+                        JPAExpressions.selectOne()
+                                .from(memberAnswerEntity)
+                                .join(coupleMemberEntity)
+                                .on(memberAnswerEntity.coupleMemberEntityId.value.eq(coupleMemberEntity.id))
+                                .where(memberAnswerEntity.coupleQuestionEntityId.value.eq(coupleQuestionEntity.id)
+                                        .and(coupleMemberEntity.memberEntityId.value.ne(memberId)))
+                                .exists(),
+                        coupleQuestionEntity.createdAt
+                ))
+                .from(coupleQuestionEntity)
+                .where(coupleQuestionEntity.coupleEntityId.value.eq(coupleId))
+                .orderBy(coupleQuestionEntity.question.level.asc())
+                .limit(1)
+                .fetchOne();
+
+        return Optional.ofNullable(dto);
+    }
+
+    @Override
+    public Optional<CoupleQuestionPersistenceAdapter.CoupleQuestionRepositoryDto> findQuestionDtoByLevel(Long memberId, Long coupleId, int level) {
+        CoupleQuestionPersistenceAdapter.CoupleQuestionRepositoryDto dto = queryFactory
+                .select(Projections.constructor(CoupleQuestionPersistenceAdapter.CoupleQuestionRepositoryDto.class,
+                        coupleQuestionEntity.id,
+                        coupleQuestionEntity.question.title,
+                        coupleQuestionEntity.question.content,
+                        coupleQuestionEntity.question.level,
+                        coupleQuestionEntity.coupleEntityId.value,
+                        coupleQuestionEntity.coupleQuestionState,
+                        coupleQuestionEntity.bothAnsweredAt,
+                        JPAExpressions.selectOne()
+                                .from(memberAnswerEntity)
+                                .join(coupleMemberEntity)
+                                .on(memberAnswerEntity.coupleMemberEntityId.value.eq(coupleMemberEntity.id))
+                                .where(memberAnswerEntity.coupleQuestionEntityId.value.eq(coupleQuestionEntity.id)
+                                        .and(coupleMemberEntity.memberEntityId.value.eq(memberId)))
+                                .exists(),
+                        JPAExpressions.selectOne()
+                                .from(memberAnswerEntity)
+                                .join(coupleMemberEntity)
+                                .on(memberAnswerEntity.coupleMemberEntityId.value.eq(coupleMemberEntity.id))
+                                .where(memberAnswerEntity.coupleQuestionEntityId.value.eq(coupleQuestionEntity.id)
+                                        .and(coupleMemberEntity.memberEntityId.value.ne(memberId)))
+                                .exists(),
+                        coupleQuestionEntity.createdAt
+                ))
+                .from(coupleQuestionEntity)
+                .where(coupleQuestionEntity.coupleEntityId.value.eq(coupleId)
+                        .and(coupleQuestionEntity.question.level.eq(level)))
+                .fetchOne();
+
+        return Optional.ofNullable(dto);
+    }
+}

--- a/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/repository/custom/MemberAnswerRepositoryCustom.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/repository/custom/MemberAnswerRepositoryCustom.java
@@ -1,0 +1,16 @@
+package makeus.cmc.malmo.adaptor.out.persistence.repository.custom;
+
+import makeus.cmc.malmo.adaptor.out.persistence.MemberAnswerPersistenceAdapter;
+import makeus.cmc.malmo.adaptor.out.persistence.entity.question.MemberAnswerEntity;
+
+import java.util.Optional;
+
+public interface MemberAnswerRepositoryCustom {
+    Optional<MemberAnswerPersistenceAdapter.AnswerRepositoryDto> findAnswersDtoByCoupleQuestionId(Long memberId, Long coupleQuestionId);
+
+    Optional<MemberAnswerEntity> findByCoupleQuestionIdAndCoupleMemberId(Long coupleQuestionEntityId, Long memberId);
+
+    boolean existsByCoupleQuestionIdAndMemberId(Long coupleQuestionEntityId, Long memberId);
+
+    Long countByCoupleQuestionIdAndMemberId(Long coupleQuestionEntityId);
+}

--- a/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/repository/custom/MemberAnswerRepositoryCustomImpl.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/repository/custom/MemberAnswerRepositoryCustomImpl.java
@@ -33,10 +33,10 @@ public class MemberAnswerRepositoryCustomImpl implements MemberAnswerRepositoryC
                 .select(Projections.constructor(MemberAnswerPersistenceAdapter.AnswerRepositoryDto.class,
                         memberEntity.nickname,
                         memberAnswerEntity.answer,
-                        coupleQuestionEntity.coupleQuestionState.ne(CoupleQuestionState.COMPLETED),
+                        coupleQuestionEntity.coupleQuestionState.ne(CoupleQuestionState.OUTDATED),
                         partnerMemberEntity.nickname,
                         partnerAnswerEntity.answer,
-                        coupleQuestionEntity.coupleQuestionState.ne(CoupleQuestionState.COMPLETED)))
+                        coupleQuestionEntity.coupleQuestionState.ne(CoupleQuestionState.OUTDATED)))
                 .from(memberAnswerEntity)
                 .join(coupleMemberEntity).on(coupleMemberEntity.id.eq(memberAnswerEntity.coupleMemberEntityId.value))
                 .join(memberEntity)
@@ -59,7 +59,7 @@ public class MemberAnswerRepositoryCustomImpl implements MemberAnswerRepositoryC
         MemberAnswerEntity result = queryFactory.selectFrom(memberAnswerEntity)
                 .join(coupleMemberEntity)
                 .on(memberAnswerEntity.coupleMemberEntityId.value.eq(coupleMemberEntity.coupleEntityId.value))
-                .where(coupleQuestionEntity.id.eq(coupleQuestionEntityId)
+                .where(memberAnswerEntity.coupleMemberEntityId.value.eq(coupleQuestionEntityId)
                         .and(coupleMemberEntity.memberEntityId.value.eq(memberId)))
                 .fetchOne();
 

--- a/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/repository/custom/MemberAnswerRepositoryCustomImpl.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/repository/custom/MemberAnswerRepositoryCustomImpl.java
@@ -1,0 +1,89 @@
+package makeus.cmc.malmo.adaptor.out.persistence.repository.custom;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import makeus.cmc.malmo.adaptor.out.persistence.MemberAnswerPersistenceAdapter;
+import makeus.cmc.malmo.adaptor.out.persistence.entity.couple.QCoupleMemberEntity;
+import makeus.cmc.malmo.adaptor.out.persistence.entity.member.QMemberEntity;
+import makeus.cmc.malmo.adaptor.out.persistence.entity.question.MemberAnswerEntity;
+import makeus.cmc.malmo.adaptor.out.persistence.entity.question.QMemberAnswerEntity;
+import makeus.cmc.malmo.domain.value.state.CoupleQuestionState;
+
+import java.util.Optional;
+
+import static makeus.cmc.malmo.adaptor.out.persistence.entity.couple.QCoupleMemberEntity.coupleMemberEntity;
+import static makeus.cmc.malmo.adaptor.out.persistence.entity.member.QMemberEntity.memberEntity;
+import static makeus.cmc.malmo.adaptor.out.persistence.entity.question.QCoupleQuestionEntity.coupleQuestionEntity;
+import static makeus.cmc.malmo.adaptor.out.persistence.entity.question.QMemberAnswerEntity.memberAnswerEntity;
+
+@RequiredArgsConstructor
+public class MemberAnswerRepositoryCustomImpl implements MemberAnswerRepositoryCustom{
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Optional<MemberAnswerPersistenceAdapter.AnswerRepositoryDto> findAnswersDtoByCoupleQuestionId(Long memberId, Long coupleQuestionId) {
+        QMemberEntity partnerMemberEntity = new QMemberEntity("partnerMemberEntity");
+        QMemberAnswerEntity partnerAnswerEntity = new QMemberAnswerEntity("partnerAnswerEntity");
+        QCoupleMemberEntity coupleMemberEntity = new QCoupleMemberEntity("coupleMemberEntity");
+        QCoupleMemberEntity partnerCoupleMemberEntity = new QCoupleMemberEntity("partnerCoupleMemberEntity");
+
+        MemberAnswerPersistenceAdapter.AnswerRepositoryDto result = queryFactory
+                .select(Projections.constructor(MemberAnswerPersistenceAdapter.AnswerRepositoryDto.class,
+                        memberEntity.nickname,
+                        memberAnswerEntity.answer,
+                        coupleQuestionEntity.coupleQuestionState.ne(CoupleQuestionState.COMPLETED),
+                        partnerMemberEntity.nickname,
+                        partnerAnswerEntity.answer,
+                        coupleQuestionEntity.coupleQuestionState.ne(CoupleQuestionState.COMPLETED)))
+                .from(memberAnswerEntity)
+                .join(coupleMemberEntity).on(coupleMemberEntity.id.eq(memberAnswerEntity.coupleMemberEntityId.value))
+                .join(memberEntity)
+                .on(coupleMemberEntity.memberEntityId.value.eq(memberEntity.id))
+                .join(coupleQuestionEntity).on(coupleQuestionEntity.id.eq(memberAnswerEntity.coupleQuestionEntityId.value))
+                .leftJoin(partnerAnswerEntity).on(partnerAnswerEntity.coupleQuestionEntityId.eq(memberAnswerEntity.coupleQuestionEntityId)
+                        .and(partnerAnswerEntity.coupleMemberEntityId.ne(memberAnswerEntity.coupleMemberEntityId)))
+                .leftJoin(partnerCoupleMemberEntity).on(partnerCoupleMemberEntity.id.eq(partnerAnswerEntity.coupleMemberEntityId.value))
+                .leftJoin(partnerMemberEntity)
+                .on(partnerCoupleMemberEntity.memberEntityId.value.eq(partnerMemberEntity.id))
+                .where(coupleQuestionEntity.id.eq(coupleQuestionId)
+                        .and(memberEntity.id.eq(memberId)))
+                .fetchOne();
+
+        return Optional.ofNullable(result);
+    }
+
+    @Override
+    public Optional<MemberAnswerEntity> findByCoupleQuestionIdAndCoupleMemberId(Long coupleQuestionEntityId, Long memberId) {
+        MemberAnswerEntity result = queryFactory.selectFrom(memberAnswerEntity)
+                .join(coupleMemberEntity)
+                .on(memberAnswerEntity.coupleMemberEntityId.value.eq(coupleMemberEntity.coupleEntityId.value))
+                .where(coupleQuestionEntity.id.eq(coupleQuestionEntityId)
+                        .and(coupleMemberEntity.memberEntityId.value.eq(memberId)))
+                .fetchOne();
+
+        return Optional.ofNullable(result);
+    }
+
+    @Override
+    public boolean existsByCoupleQuestionIdAndMemberId(Long coupleQuestionEntityId, Long memberId) {
+        Long count = queryFactory.select(memberAnswerEntity.count())
+                .from(memberAnswerEntity)
+                .join(coupleMemberEntity)
+                .on(memberAnswerEntity.coupleMemberEntityId.value.eq(coupleMemberEntity.id))
+                .where(memberAnswerEntity.coupleQuestionEntityId.value.eq(coupleQuestionEntityId)
+                        .and(coupleMemberEntity.memberEntityId.value.eq(memberId)))
+                .fetchOne();
+
+        return count != null && count > 0;
+    }
+
+    @Override
+    public Long countByCoupleQuestionIdAndMemberId(Long coupleQuestionEntityId) {
+        return queryFactory.select(memberAnswerEntity.count())
+                .from(memberAnswerEntity)
+                .where(memberAnswerEntity.coupleQuestionEntityId.value.eq(coupleQuestionEntityId))
+                .fetchOne();
+    }
+}

--- a/src/main/java/makeus/cmc/malmo/application/port/in/AnswerQuestionUseCase.java
+++ b/src/main/java/makeus/cmc/malmo/application/port/in/AnswerQuestionUseCase.java
@@ -1,0 +1,17 @@
+package makeus.cmc.malmo.application.port.in;
+
+import lombok.Builder;
+import lombok.Data;
+
+public interface AnswerQuestionUseCase {
+
+    void answerQuestion(AnswerQuestionCommand command);
+    void updateAnswer(AnswerQuestionCommand command);
+
+    @Data
+    @Builder
+    class AnswerQuestionCommand {
+        private Long userId;
+        private String answer;
+    }
+}

--- a/src/main/java/makeus/cmc/malmo/application/port/in/GetQuestionAnswerUseCase.java
+++ b/src/main/java/makeus/cmc/malmo/application/port/in/GetQuestionAnswerUseCase.java
@@ -1,0 +1,31 @@
+package makeus.cmc.malmo.application.port.in;
+
+import lombok.Builder;
+import lombok.Data;
+
+public interface GetQuestionAnswerUseCase {
+
+    AnswerResponseDto getQuestionAnswers(GetQuestionAnswerCommand command);
+
+    @Data
+    @Builder
+    class GetQuestionAnswerCommand {
+        private Long userId;
+        private Long coupleQuestionId;
+    }
+
+    @Data
+    @Builder
+    class AnswerResponseDto {
+        private AnswerDto me;
+        private AnswerDto partner;
+    }
+
+    @Data
+    @Builder
+    class AnswerDto {
+        private String nickname;
+        private String answer;
+        private boolean updatable;
+    }
+}

--- a/src/main/java/makeus/cmc/malmo/application/port/in/GetQuestionUseCase.java
+++ b/src/main/java/makeus/cmc/malmo/application/port/in/GetQuestionUseCase.java
@@ -1,0 +1,31 @@
+package makeus.cmc.malmo.application.port.in;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+public interface GetQuestionUseCase {
+
+    GetQuestionResponse getTodayQuestion(GetTodayQuestionCommand command);
+
+
+    @Data
+    @Builder
+    class GetTodayQuestionCommand {
+        private Long userId;
+    }
+
+
+    @Data
+    @Builder
+    class GetQuestionResponse {
+        private Long coupleQuestionId;
+        private String title;
+        private String content;
+        private int level;
+        private boolean meAnswered;
+        private boolean partnerAnswered;
+        private LocalDateTime createdAt;
+    }
+}

--- a/src/main/java/makeus/cmc/malmo/application/port/in/GetQuestionUseCase.java
+++ b/src/main/java/makeus/cmc/malmo/application/port/in/GetQuestionUseCase.java
@@ -8,12 +8,20 @@ import java.time.LocalDateTime;
 public interface GetQuestionUseCase {
 
     GetQuestionResponse getTodayQuestion(GetTodayQuestionCommand command);
+    GetQuestionResponse getQuestion(GetQuestionCommand command);
 
 
     @Data
     @Builder
     class GetTodayQuestionCommand {
         private Long userId;
+    }
+
+    @Data
+    @Builder
+    class GetQuestionCommand {
+        private Long userId;
+        private int level;
     }
 
 

--- a/src/main/java/makeus/cmc/malmo/application/port/out/LoadCouplePort.java
+++ b/src/main/java/makeus/cmc/malmo/application/port/out/LoadCouplePort.java
@@ -1,0 +1,10 @@
+package makeus.cmc.malmo.application.port.out;
+
+import makeus.cmc.malmo.domain.value.id.CoupleId;
+import makeus.cmc.malmo.domain.value.id.CoupleMemberId;
+import makeus.cmc.malmo.domain.value.id.MemberId;
+
+public interface LoadCouplePort {
+    CoupleId loadCoupleIdByMemberId(MemberId memberId);
+    CoupleMemberId loadCoupleMemberIdByMemberId(MemberId memberId);
+}

--- a/src/main/java/makeus/cmc/malmo/application/port/out/LoadCouplePort.java
+++ b/src/main/java/makeus/cmc/malmo/application/port/out/LoadCouplePort.java
@@ -5,5 +5,6 @@ import makeus.cmc.malmo.domain.value.id.CoupleMemberId;
 import makeus.cmc.malmo.domain.value.id.MemberId;
 
 public interface LoadCouplePort {
+    CoupleId loadCoupleIdByMemberId(MemberId memberId);
     CoupleMemberId loadCoupleMemberIdByMemberId(MemberId memberId);
 }

--- a/src/main/java/makeus/cmc/malmo/application/port/out/LoadCouplePort.java
+++ b/src/main/java/makeus/cmc/malmo/application/port/out/LoadCouplePort.java
@@ -5,6 +5,5 @@ import makeus.cmc.malmo.domain.value.id.CoupleMemberId;
 import makeus.cmc.malmo.domain.value.id.MemberId;
 
 public interface LoadCouplePort {
-    CoupleId loadCoupleIdByMemberId(MemberId memberId);
     CoupleMemberId loadCoupleMemberIdByMemberId(MemberId memberId);
 }

--- a/src/main/java/makeus/cmc/malmo/application/port/out/LoadCoupleQuestionPort.java
+++ b/src/main/java/makeus/cmc/malmo/application/port/out/LoadCoupleQuestionPort.java
@@ -4,13 +4,14 @@ import makeus.cmc.malmo.domain.model.question.CoupleQuestion;
 import makeus.cmc.malmo.domain.service.CoupleQuestionDomainService;
 import makeus.cmc.malmo.domain.value.id.CoupleId;
 import makeus.cmc.malmo.domain.value.id.CoupleQuestionId;
+import makeus.cmc.malmo.domain.value.id.MemberId;
 
 import java.util.Optional;
 
 public interface LoadCoupleQuestionPort {
     Optional<CoupleQuestion> loadMaxLevelCoupleQuestion(CoupleId coupleId);
-    Optional<CoupleQuestionDomainService.CoupleQuestionDto> getMaxLevelQuestionDto(CoupleId coupleId);
-    Optional<CoupleQuestionDomainService.CoupleQuestionDto> getCoupleQuestionDtoByLevel(CoupleId coupleId, int level);
+    Optional<CoupleQuestionDomainService.CoupleQuestionDto> getMaxLevelQuestionDto(MemberId memberId, CoupleId coupleId);
+    Optional<CoupleQuestionDomainService.CoupleQuestionDto> getCoupleQuestionDtoByLevel(MemberId memberId, CoupleId coupleId, int level);
 
     Optional<CoupleQuestion> loadCoupleQuestionById(CoupleQuestionId coupleQuestionId);
 }

--- a/src/main/java/makeus/cmc/malmo/application/port/out/LoadCoupleQuestionPort.java
+++ b/src/main/java/makeus/cmc/malmo/application/port/out/LoadCoupleQuestionPort.java
@@ -1,0 +1,16 @@
+package makeus.cmc.malmo.application.port.out;
+
+import makeus.cmc.malmo.domain.model.question.CoupleQuestion;
+import makeus.cmc.malmo.domain.service.CoupleQuestionDomainService;
+import makeus.cmc.malmo.domain.value.id.CoupleId;
+import makeus.cmc.malmo.domain.value.id.CoupleQuestionId;
+
+import java.util.Optional;
+
+public interface LoadCoupleQuestionPort {
+    Optional<CoupleQuestion> loadMaxLevelCoupleQuestion(CoupleId coupleId);
+    Optional<CoupleQuestionDomainService.CoupleQuestionDto> getMaxLevelQuestionDto(CoupleId coupleId);
+    Optional<CoupleQuestionDomainService.CoupleQuestionDto> getCoupleQuestionDtoByLevel(CoupleId coupleId, int level);
+
+    Optional<CoupleQuestion> loadCoupleQuestionById(CoupleQuestionId coupleQuestionId);
+}

--- a/src/main/java/makeus/cmc/malmo/application/port/out/LoadMemberAnswerPort.java
+++ b/src/main/java/makeus/cmc/malmo/application/port/out/LoadMemberAnswerPort.java
@@ -1,0 +1,17 @@
+package makeus.cmc.malmo.application.port.out;
+
+import makeus.cmc.malmo.domain.model.question.MemberAnswer;
+import makeus.cmc.malmo.domain.service.CoupleQuestionDomainService;
+import makeus.cmc.malmo.domain.value.id.CoupleQuestionId;
+import makeus.cmc.malmo.domain.value.id.MemberId;
+
+import java.util.Optional;
+
+public interface LoadMemberAnswerPort {
+    Optional<CoupleQuestionDomainService.MemberAnswersDto> getQuestionAnswers(CoupleQuestionId coupleQuestionId);
+    Optional<MemberAnswer> getMemberAnswer(CoupleQuestionId coupleQuestionId, MemberId memberId);
+
+    boolean isMemberAnswered(CoupleQuestionId coupleQuestionId, MemberId memberId);
+
+    long countAnswers(CoupleQuestionId coupleQuestionId);
+}

--- a/src/main/java/makeus/cmc/malmo/application/port/out/LoadMemberAnswerPort.java
+++ b/src/main/java/makeus/cmc/malmo/application/port/out/LoadMemberAnswerPort.java
@@ -8,7 +8,7 @@ import makeus.cmc.malmo.domain.value.id.MemberId;
 import java.util.Optional;
 
 public interface LoadMemberAnswerPort {
-    Optional<CoupleQuestionDomainService.MemberAnswersDto> getQuestionAnswers(CoupleQuestionId coupleQuestionId);
+    Optional<CoupleQuestionDomainService.MemberAnswersDto> getQuestionAnswers(MemberId memberId, CoupleQuestionId coupleQuestionId);
     Optional<MemberAnswer> getMemberAnswer(CoupleQuestionId coupleQuestionId, MemberId memberId);
 
     boolean isMemberAnswered(CoupleQuestionId coupleQuestionId, MemberId memberId);

--- a/src/main/java/makeus/cmc/malmo/application/port/out/LoadQuestionPort.java
+++ b/src/main/java/makeus/cmc/malmo/application/port/out/LoadQuestionPort.java
@@ -1,0 +1,9 @@
+package makeus.cmc.malmo.application.port.out;
+
+import makeus.cmc.malmo.domain.model.question.Question;
+
+import java.util.Optional;
+
+public interface LoadQuestionPort {
+    Optional<Question> loadQuestionByLevel(int level);
+}

--- a/src/main/java/makeus/cmc/malmo/application/port/out/LoadTempCoupleQuestionPort.java
+++ b/src/main/java/makeus/cmc/malmo/application/port/out/LoadTempCoupleQuestionPort.java
@@ -1,0 +1,10 @@
+package makeus.cmc.malmo.application.port.out;
+
+import makeus.cmc.malmo.domain.model.question.TempCoupleQuestion;
+import makeus.cmc.malmo.domain.value.id.MemberId;
+
+import java.util.Optional;
+
+public interface LoadTempCoupleQuestionPort {
+    Optional<TempCoupleQuestion> loadTempCoupleQuestionByMemberId(MemberId memberId);
+}

--- a/src/main/java/makeus/cmc/malmo/application/port/out/SaveCoupleQuestionPort.java
+++ b/src/main/java/makeus/cmc/malmo/application/port/out/SaveCoupleQuestionPort.java
@@ -1,10 +1,7 @@
 package makeus.cmc.malmo.application.port.out;
 
 import makeus.cmc.malmo.domain.model.question.CoupleQuestion;
-import makeus.cmc.malmo.domain.model.question.MemberAnswer;
 
 public interface SaveCoupleQuestionPort {
     CoupleQuestion saveCoupleQuestion(CoupleQuestion coupleQuestion);
-
-    void saveMemberAnswer(MemberAnswer memberAnswer);
 }

--- a/src/main/java/makeus/cmc/malmo/application/port/out/SaveCoupleQuestionPort.java
+++ b/src/main/java/makeus/cmc/malmo/application/port/out/SaveCoupleQuestionPort.java
@@ -1,0 +1,10 @@
+package makeus.cmc.malmo.application.port.out;
+
+import makeus.cmc.malmo.domain.model.question.CoupleQuestion;
+import makeus.cmc.malmo.domain.model.question.MemberAnswer;
+
+public interface SaveCoupleQuestionPort {
+    CoupleQuestion saveCoupleQuestion(CoupleQuestion coupleQuestion);
+
+    void saveMemberAnswer(MemberAnswer memberAnswer);
+}

--- a/src/main/java/makeus/cmc/malmo/application/port/out/SaveMemberAnswerPort.java
+++ b/src/main/java/makeus/cmc/malmo/application/port/out/SaveMemberAnswerPort.java
@@ -1,0 +1,7 @@
+package makeus.cmc.malmo.application.port.out;
+
+import makeus.cmc.malmo.domain.model.question.MemberAnswer;
+
+public interface SaveMemberAnswerPort {
+    MemberAnswer saveMemberAnswer(MemberAnswer memberAnswer);
+}

--- a/src/main/java/makeus/cmc/malmo/application/port/out/SaveTempCoupleQuestionPort.java
+++ b/src/main/java/makeus/cmc/malmo/application/port/out/SaveTempCoupleQuestionPort.java
@@ -1,0 +1,7 @@
+package makeus.cmc.malmo.application.port.out;
+
+import makeus.cmc.malmo.domain.model.question.TempCoupleQuestion;
+
+public interface SaveTempCoupleQuestionPort {
+    TempCoupleQuestion saveTempCoupleQuestion(TempCoupleQuestion tempCoupleQuestion);
+}

--- a/src/main/java/makeus/cmc/malmo/application/service/CoupleQuestionService.java
+++ b/src/main/java/makeus/cmc/malmo/application/service/CoupleQuestionService.java
@@ -19,7 +19,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-@Transactional(readOnly = true)
+@Transactional
 @RequiredArgsConstructor
 public class CoupleQuestionService implements GetQuestionUseCase, GetQuestionAnswerUseCase, AnswerQuestionUseCase {
 
@@ -36,7 +36,6 @@ public class CoupleQuestionService implements GetQuestionUseCase, GetQuestionAns
             // 커플 사용자에게는 오늘의 커플 질문을 제공
             // 멤버가 속한 Couple의 가장 레벨이 높은 CoupleQuestion을 조회
             CoupleId coupleId = coupleDomainService.getCoupleIdByMemberId(MemberId.of(command.getUserId()));
-            // TODO : DTO 매핑 필요
             CoupleQuestionDomainService.CoupleQuestionDto maxLevelQuestion =
                     coupleQuestionDomainService.getMaxLevelQuestionDto(MemberId.of(command.getUserId()), coupleId);
 
@@ -52,6 +51,7 @@ public class CoupleQuestionService implements GetQuestionUseCase, GetQuestionAns
                         .content(newQuestion.getQuestion().getContent())
                         .meAnswered(false)
                         .partnerAnswered(false)
+                        .level(newQuestion.getQuestion().getLevel())
                         .createdAt(newQuestion.getCreatedAt())
                         .build();
             }
@@ -62,6 +62,7 @@ public class CoupleQuestionService implements GetQuestionUseCase, GetQuestionAns
                     .content(maxLevelQuestion.getContent())
                     .meAnswered(maxLevelQuestion.isMeAnswered())
                     .partnerAnswered(maxLevelQuestion.isPartnerAnswered())
+                    .level(maxLevelQuestion.getLevel())
                     .createdAt(maxLevelQuestion.getCreatedAt())
                     .build();
         }
@@ -78,6 +79,7 @@ public class CoupleQuestionService implements GetQuestionUseCase, GetQuestionAns
                     .title(tempCoupleQuestion.getQuestion().getTitle())
                     .content(tempCoupleQuestion.getQuestion().getContent())
                     .meAnswered(tempCoupleQuestion.isAnswered())
+                    .level(CoupleQuestionDomainService.FIRST_QUESTION_LEVEL)
                     .partnerAnswered(false)
                     .createdAt(tempCoupleQuestion.getCreatedAt())
                     .build();
@@ -88,7 +90,6 @@ public class CoupleQuestionService implements GetQuestionUseCase, GetQuestionAns
     @CheckCoupleMember
     public GetQuestionResponse getQuestion(GetQuestionCommand command) {
         CoupleId coupleId = coupleDomainService.getCoupleIdByMemberId(MemberId.of(command.getUserId()));
-        // TODO : DTO 매핑 필요
         CoupleQuestionDomainService.CoupleQuestionDto question =
                 coupleQuestionDomainService.getCoupleQuestionDtoByLevel(MemberId.of(command.getUserId()), coupleId, command.getLevel());
 
@@ -114,7 +115,6 @@ public class CoupleQuestionService implements GetQuestionUseCase, GetQuestionAns
                     CoupleQuestionId.of(command.getCoupleQuestionId()),
                     coupleId
             );
-            // TODO : DTO 매핑 필요
             CoupleQuestionDomainService.MemberAnswersDto answers =
                     coupleQuestionDomainService.getQuestionAnswers(MemberId.of(command.getUserId()), CoupleQuestionId.of(command.getCoupleQuestionId()));
 
@@ -195,14 +195,14 @@ public class CoupleQuestionService implements GetQuestionUseCase, GetQuestionAns
             CoupleId coupleId = coupleDomainService.getCoupleIdByMemberId(MemberId.of(request.getUserId()));
             CoupleQuestion coupleQuestion = coupleQuestionDomainService.getMaxLevelQuestion(coupleId);
 
-            // 답변을 수정 TODO : 답변 존재 여부 체크 필요
+            // 답변을 수정
             coupleQuestionDomainService.updateAnswer(coupleQuestion, MemberId.of(request.getUserId()), request.getAnswer());
         }
         else {
             // 커플이 아닌 사용자는 TempCoupleQuestion 답변 수정
             TempCoupleQuestion tempCoupleQuestion = coupleQuestionDomainService.getTempCoupleQuestion(MemberId.of(request.getUserId()));
 
-            // 답변을 수정 TODO : 답변 존재 여부 체크 필요
+            // 답변을 수정
             coupleQuestionDomainService.updateAnswer(tempCoupleQuestion, request.getAnswer());
         }
     }

--- a/src/main/java/makeus/cmc/malmo/application/service/CoupleQuestionService.java
+++ b/src/main/java/makeus/cmc/malmo/application/service/CoupleQuestionService.java
@@ -1,6 +1,7 @@
 package makeus.cmc.malmo.application.service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import makeus.cmc.malmo.adaptor.in.aop.CheckCoupleMember;
 import makeus.cmc.malmo.application.port.in.AnswerQuestionUseCase;
 import makeus.cmc.malmo.application.port.in.GetQuestionAnswerUseCase;
@@ -18,6 +19,7 @@ import makeus.cmc.malmo.domain.value.id.MemberId;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -71,9 +73,6 @@ public class CoupleQuestionService implements GetQuestionUseCase, GetQuestionAns
             // TempCoupleQuestion을 조회, 없으면 생성
             TempCoupleQuestion tempCoupleQuestion = coupleQuestionDomainService.getTempCoupleQuestion(MemberId.of(command.getUserId()));
 
-            // TODO : 커플이 생성되면 TempCoupleQuestion을 CoupleQuestion으로 변환,
-            //  TempCoupleQuestion 없으면 1단계의 CoupleQustion을 생성
-
             return GetQuestionResponse.builder()
                     .coupleQuestionId(tempCoupleQuestion.getId())
                     .title(tempCoupleQuestion.getQuestion().getTitle())
@@ -97,6 +96,7 @@ public class CoupleQuestionService implements GetQuestionUseCase, GetQuestionAns
                 .coupleQuestionId(question.getId())
                 .title(question.getTitle())
                 .content(question.getContent())
+                .level(question.getLevel())
                 .meAnswered(question.isMeAnswered())
                 .partnerAnswered(question.isPartnerAnswered())
                 .createdAt(question.getCreatedAt())

--- a/src/main/java/makeus/cmc/malmo/application/service/CoupleQuestionService.java
+++ b/src/main/java/makeus/cmc/malmo/application/service/CoupleQuestionService.java
@@ -116,7 +116,7 @@ public class CoupleQuestionService implements GetQuestionUseCase, GetQuestionAns
             );
             // TODO : DTO 매핑 필요
             CoupleQuestionDomainService.MemberAnswersDto answers =
-                    coupleQuestionDomainService.getQuestionAnswers(CoupleQuestionId.of(command.getCoupleQuestionId()));
+                    coupleQuestionDomainService.getQuestionAnswers(MemberId.of(command.getUserId()), CoupleQuestionId.of(command.getCoupleQuestionId()));
 
 
             return AnswerResponseDto.builder()

--- a/src/main/java/makeus/cmc/malmo/application/service/CoupleQuestionService.java
+++ b/src/main/java/makeus/cmc/malmo/application/service/CoupleQuestionService.java
@@ -1,6 +1,8 @@
 package makeus.cmc.malmo.application.service;
 
 import lombok.RequiredArgsConstructor;
+import makeus.cmc.malmo.adaptor.in.aop.CheckCoupleMember;
+import makeus.cmc.malmo.adaptor.in.web.docs.ApiCommonResponses;
 import makeus.cmc.malmo.application.port.in.GetQuestionUseCase;
 import makeus.cmc.malmo.application.port.out.ValidateMemberPort;
 import makeus.cmc.malmo.domain.model.question.CoupleQuestion;
@@ -72,5 +74,22 @@ public class CoupleQuestionService implements GetQuestionUseCase {
                     .createdAt(tempCoupleQuestion.getCreatedAt())
                     .build();
         }
+    }
+
+    @Override
+    @CheckCoupleMember
+    public GetQuestionResponse getQuestion(GetQuestionCommand command) {
+        CoupleId coupleId = coupleDomainService.getCoupleIdByMemberId(MemberId.of(command.getUserId()));
+        CoupleQuestionDomainService.QuestionRepositoryDto question =
+                coupleQuestionDomainService.getCoupleQuestionByLevel(coupleId, command.getLevel());
+
+        return GetQuestionResponse.builder()
+                .coupleQuestionId(question.getId())
+                .title(question.getTitle())
+                .content(question.getContent())
+                .meAnswered(question.isMeAnswered())
+                .partnerAnswered(question.isPartnerAnswered())
+                .createdAt(question.getCreatedAt())
+                .build();
     }
 }

--- a/src/main/java/makeus/cmc/malmo/application/service/CoupleQuestionService.java
+++ b/src/main/java/makeus/cmc/malmo/application/service/CoupleQuestionService.java
@@ -38,7 +38,7 @@ public class CoupleQuestionService implements GetQuestionUseCase, GetQuestionAns
             CoupleId coupleId = coupleDomainService.getCoupleIdByMemberId(MemberId.of(command.getUserId()));
             // TODO : DTO 매핑 필요
             CoupleQuestionDomainService.CoupleQuestionDto maxLevelQuestion =
-                    coupleQuestionDomainService.getMaxLevelQuestionDto(coupleId);
+                    coupleQuestionDomainService.getMaxLevelQuestionDto(MemberId.of(command.getUserId()), coupleId);
 
             // CoupleQuestion의 bothAnsweredAt이 now()의 전날인 경우 (날짜만 비교), 다음 단계의 CoupleQuestion을 생성
             if (coupleQuestionDomainService.needsNextQuestion(maxLevelQuestion.getBothAnsweredAt())) {
@@ -90,7 +90,7 @@ public class CoupleQuestionService implements GetQuestionUseCase, GetQuestionAns
         CoupleId coupleId = coupleDomainService.getCoupleIdByMemberId(MemberId.of(command.getUserId()));
         // TODO : DTO 매핑 필요
         CoupleQuestionDomainService.CoupleQuestionDto question =
-                coupleQuestionDomainService.getCoupleQuestionDtoByLevel(coupleId, command.getLevel());
+                coupleQuestionDomainService.getCoupleQuestionDtoByLevel(MemberId.of(command.getUserId()), coupleId, command.getLevel());
 
         return GetQuestionResponse.builder()
                 .coupleQuestionId(question.getId())

--- a/src/main/java/makeus/cmc/malmo/application/service/CoupleService.java
+++ b/src/main/java/makeus/cmc/malmo/application/service/CoupleService.java
@@ -8,7 +8,9 @@ import makeus.cmc.malmo.domain.model.couple.Couple;
 import makeus.cmc.malmo.domain.model.member.Member;
 import makeus.cmc.malmo.domain.service.ChatRoomDomainService;
 import makeus.cmc.malmo.domain.service.CoupleDomainService;
+import makeus.cmc.malmo.domain.service.CoupleQuestionDomainService;
 import makeus.cmc.malmo.domain.service.InviteCodeDomainService;
+import makeus.cmc.malmo.domain.value.id.CoupleId;
 import makeus.cmc.malmo.domain.value.id.InviteCodeValue;
 import makeus.cmc.malmo.domain.value.id.MemberId;
 import org.springframework.stereotype.Service;
@@ -24,6 +26,8 @@ public class CoupleService implements CoupleLinkUseCase {
     private final InviteCodeDomainService inviteCodeDomainService;
     private final CoupleDomainService coupleDomainService;
     private final ChatRoomDomainService chatRoomDomainService;
+
+    private final CoupleQuestionDomainService coupleQuestionDomainService;
 
     private final SendSseEventPort sendSseEventPort;
 
@@ -45,6 +49,14 @@ public class CoupleService implements CoupleLinkUseCase {
         );
 
         Couple savedCouple = saveCouplePort.saveCouple(couple);
+
+        // 커플이 생성되면 TempCoupleQuestion을 CoupleQuestion으로 변환,
+        //  TempCoupleQuestion 없으면 1단계의 CoupleQustion을 생성
+        coupleQuestionDomainService.createFirstCoupleQuestion(
+                CoupleId.of(savedCouple.getId()),
+                MemberId.of(command.getUserId()),
+                MemberId.of(partner.getId())
+        );
 
         // 커플 연결 전 일시 정지 상태의 채팅방을 활성화 (나 & 상대방)
         chatRoomDomainService.updateMemberPausedChatRoomStateToAlive(MemberId.of(command.getUserId()));

--- a/src/main/java/makeus/cmc/malmo/domain/exception/CoupleQuestionNotFoundException.java
+++ b/src/main/java/makeus/cmc/malmo/domain/exception/CoupleQuestionNotFoundException.java
@@ -1,0 +1,4 @@
+package makeus.cmc.malmo.domain.exception;
+
+public class CoupleQuestionNotFoundException extends RuntimeException {
+}

--- a/src/main/java/makeus/cmc/malmo/domain/exception/NotCoupleMemberException.java
+++ b/src/main/java/makeus/cmc/malmo/domain/exception/NotCoupleMemberException.java
@@ -1,4 +1,4 @@
-package makeus.cmc.malmo.domain;
+package makeus.cmc.malmo.domain.exception;
 
 public class NotCoupleMemberException extends RuntimeException {
     public NotCoupleMemberException() {

--- a/src/main/java/makeus/cmc/malmo/domain/exception/QuestionNotFoundException.java
+++ b/src/main/java/makeus/cmc/malmo/domain/exception/QuestionNotFoundException.java
@@ -1,0 +1,4 @@
+package makeus.cmc.malmo.domain.exception;
+
+public class QuestionNotFoundException extends RuntimeException {
+}

--- a/src/main/java/makeus/cmc/malmo/domain/model/question/CoupleQuestion.java
+++ b/src/main/java/makeus/cmc/malmo/domain/model/question/CoupleQuestion.java
@@ -55,4 +55,17 @@ public class CoupleQuestion {
         return this.coupleQuestionState != CoupleQuestionState.COMPLETED;
     }
 
+    public static CoupleQuestion from(Long id, Question question, CoupleId coupleId, CoupleQuestionState coupleQuestionState, LocalDateTime bothAnsweredAt, LocalDateTime createdAt, LocalDateTime modifiedAt, LocalDateTime deletedAt) {
+        return CoupleQuestion.builder()
+                .id(id)
+                .question(question)
+                .coupleId(coupleId)
+                .coupleQuestionState(coupleQuestionState)
+                .bothAnsweredAt(bothAnsweredAt)
+                .createdAt(createdAt)
+                .modifiedAt(modifiedAt)
+                .deletedAt(deletedAt)
+                .build();
+    }
+
 }

--- a/src/main/java/makeus/cmc/malmo/domain/model/question/CoupleQuestion.java
+++ b/src/main/java/makeus/cmc/malmo/domain/model/question/CoupleQuestion.java
@@ -51,8 +51,12 @@ public class CoupleQuestion {
         this.bothAnsweredAt = LocalDateTime.now();
     }
 
+    public void expire() {
+        this.coupleQuestionState = CoupleQuestionState.OUTDATED;
+    }
+
     public boolean isUpdatable() {
-        return this.coupleQuestionState != CoupleQuestionState.COMPLETED;
+        return this.coupleQuestionState != CoupleQuestionState.OUTDATED;
     }
 
     public static CoupleQuestion from(Long id, Question question, CoupleId coupleId, CoupleQuestionState coupleQuestionState, LocalDateTime bothAnsweredAt, LocalDateTime createdAt, LocalDateTime modifiedAt, LocalDateTime deletedAt) {

--- a/src/main/java/makeus/cmc/malmo/domain/model/question/CoupleQuestion.java
+++ b/src/main/java/makeus/cmc/malmo/domain/model/question/CoupleQuestion.java
@@ -3,12 +3,12 @@ package makeus.cmc.malmo.domain.model.question;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
-import makeus.cmc.malmo.domain.model.couple.Couple;
 import makeus.cmc.malmo.domain.value.id.CoupleId;
-import makeus.cmc.malmo.domain.value.id.QuestionId;
+import makeus.cmc.malmo.domain.value.id.CoupleMemberId;
+import makeus.cmc.malmo.domain.value.id.CoupleQuestionId;
 import makeus.cmc.malmo.domain.value.state.CoupleQuestionState;
+import makeus.cmc.malmo.domain.value.state.MemberAnswerState;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Getter
@@ -24,5 +24,35 @@ public class CoupleQuestion {
     private LocalDateTime createdAt;
     private LocalDateTime modifiedAt;
     private LocalDateTime deletedAt;
+
+    public static CoupleQuestion createCoupleQuestion(Question question, CoupleId coupleId) {
+        return CoupleQuestion.builder()
+                .question(question)
+                .coupleId(coupleId)
+                .coupleQuestionState(CoupleQuestionState.ALIVE)
+                .build();
+    }
+
+    public boolean isOwnedBy(CoupleId coupleId) {
+        return this.coupleId.getValue().equals(coupleId.getValue());
+    }
+
+    public MemberAnswer createMemberAnswer(CoupleMemberId coupleMemberId, String answer) {
+        return MemberAnswer.builder()
+                .coupleQuestionId(CoupleQuestionId.of(this.id))
+                .coupleMemberId(coupleMemberId)
+                .answer(answer)
+                .memberAnswerState(MemberAnswerState.ALIVE)
+                .build();
+    }
+
+    public void complete() {
+        this.coupleQuestionState = CoupleQuestionState.COMPLETED;
+        this.bothAnsweredAt = LocalDateTime.now();
+    }
+
+    public boolean isUpdatable() {
+        return this.coupleQuestionState != CoupleQuestionState.COMPLETED;
+    }
 
 }

--- a/src/main/java/makeus/cmc/malmo/domain/model/question/MemberAnswer.java
+++ b/src/main/java/makeus/cmc/malmo/domain/model/question/MemberAnswer.java
@@ -4,6 +4,8 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import makeus.cmc.malmo.domain.model.couple.CoupleMember;
+import makeus.cmc.malmo.domain.value.id.CoupleMemberId;
+import makeus.cmc.malmo.domain.value.id.CoupleQuestionId;
 import makeus.cmc.malmo.domain.value.state.MemberAnswerState;
 
 import java.time.LocalDateTime;
@@ -12,8 +14,8 @@ import java.time.LocalDateTime;
 @Builder(access = AccessLevel.PRIVATE)
 public class MemberAnswer {
     private Long id;
-    private CoupleQuestion coupleQuestion;
-    private CoupleMember coupleMember;
+    private CoupleQuestionId coupleQuestionId;
+    private CoupleMemberId coupleMemberId;
     private String answer;
     private MemberAnswerState memberAnswerState;
 

--- a/src/main/java/makeus/cmc/malmo/domain/model/question/MemberAnswer.java
+++ b/src/main/java/makeus/cmc/malmo/domain/model/question/MemberAnswer.java
@@ -11,7 +11,7 @@ import makeus.cmc.malmo.domain.value.state.MemberAnswerState;
 import java.time.LocalDateTime;
 
 @Getter
-@Builder(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PACKAGE)
 public class MemberAnswer {
     private Long id;
     private CoupleQuestionId coupleQuestionId;
@@ -23,4 +23,8 @@ public class MemberAnswer {
     private LocalDateTime createdAt;
     private LocalDateTime modifiedAt;
     private LocalDateTime deletedAt;
+
+    public void updateAnswer(String answer) {
+        this.answer = answer;
+    }
 }

--- a/src/main/java/makeus/cmc/malmo/domain/model/question/MemberAnswer.java
+++ b/src/main/java/makeus/cmc/malmo/domain/model/question/MemberAnswer.java
@@ -27,4 +27,17 @@ public class MemberAnswer {
     public void updateAnswer(String answer) {
         this.answer = answer;
     }
+
+    public static MemberAnswer from(Long id, CoupleQuestionId coupleQuestionId, CoupleMemberId coupleMemberId, String answer, MemberAnswerState memberAnswerState, LocalDateTime createdAt, LocalDateTime modifiedAt, LocalDateTime deletedAt) {
+        return MemberAnswer.builder()
+                .id(id)
+                .coupleQuestionId(coupleQuestionId)
+                .coupleMemberId(coupleMemberId)
+                .answer(answer)
+                .memberAnswerState(memberAnswerState)
+                .createdAt(createdAt)
+                .modifiedAt(modifiedAt)
+                .deletedAt(deletedAt)
+                .build();
+    }
 }

--- a/src/main/java/makeus/cmc/malmo/domain/model/question/Question.java
+++ b/src/main/java/makeus/cmc/malmo/domain/model/question/Question.java
@@ -18,4 +18,16 @@ public class Question {
     private LocalDateTime createdAt;
     private LocalDateTime modifiedAt;
     private LocalDateTime deletedAt;
+
+    public static Question from(Long id, String title, String content, int level, LocalDateTime createdAt, LocalDateTime modifiedAt, LocalDateTime deletedAt) {
+        return Question.builder()
+                .id(id)
+                .title(title)
+                .content(content)
+                .level(level)
+                .createdAt(createdAt)
+                .modifiedAt(modifiedAt)
+                .deletedAt(deletedAt)
+                .build();
+    }
 }

--- a/src/main/java/makeus/cmc/malmo/domain/model/question/Question.java
+++ b/src/main/java/makeus/cmc/malmo/domain/model/question/Question.java
@@ -12,6 +12,7 @@ public class Question {
     private Long id;
     private String title;
     private String content;
+    private int level;
 
     // BaseTimeEntity fields
     private LocalDateTime createdAt;

--- a/src/main/java/makeus/cmc/malmo/domain/model/question/TempCoupleQuestion.java
+++ b/src/main/java/makeus/cmc/malmo/domain/model/question/TempCoupleQuestion.java
@@ -3,26 +3,28 @@ package makeus.cmc.malmo.domain.model.question;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
-import makeus.cmc.malmo.domain.model.couple.Couple;
 import makeus.cmc.malmo.domain.value.id.CoupleId;
+import makeus.cmc.malmo.domain.value.id.MemberId;
 import makeus.cmc.malmo.domain.value.id.QuestionId;
 import makeus.cmc.malmo.domain.value.state.CoupleQuestionState;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Getter
 @Builder(access = AccessLevel.PRIVATE)
-public class CoupleQuestion {
+public class TempCoupleQuestion {
     private Long id;
     private Question question;
-    private CoupleId coupleId;
+    private MemberId memberId;
     private CoupleQuestionState coupleQuestionState;
-    private LocalDateTime bothAnsweredAt;
+    private String answer;
 
     // BaseTimeEntity fields
     private LocalDateTime createdAt;
     private LocalDateTime modifiedAt;
     private LocalDateTime deletedAt;
 
+    public boolean isAnswered() {
+        return answer != null && !answer.isEmpty();
+    }
 }

--- a/src/main/java/makeus/cmc/malmo/domain/model/question/TempCoupleQuestion.java
+++ b/src/main/java/makeus/cmc/malmo/domain/model/question/TempCoupleQuestion.java
@@ -18,6 +18,8 @@ public class TempCoupleQuestion {
     private MemberId memberId;
     private String answer;
 
+    private CoupleQuestionState coupleQuestionState;
+
     // BaseTimeEntity fields
     private LocalDateTime createdAt;
     private LocalDateTime modifiedAt;
@@ -27,6 +29,7 @@ public class TempCoupleQuestion {
         return TempCoupleQuestion.builder()
                 .question(question)
                 .memberId(memberId)
+                .coupleQuestionState(CoupleQuestionState.ALIVE)
                 .build();
     }
 
@@ -38,12 +41,17 @@ public class TempCoupleQuestion {
         this.answer = answer;
     }
 
-    public static TempCoupleQuestion from(Long id, Question question, MemberId memberId, String answer, LocalDateTime createdAt, LocalDateTime modifiedAt, LocalDateTime deletedAt) {
+    public void usedForCoupleQuestion() {
+        this.coupleQuestionState = CoupleQuestionState.DELETED;
+    }
+
+    public static TempCoupleQuestion from(Long id, Question question, MemberId memberId, String answer, CoupleQuestionState coupleQuestionState, LocalDateTime createdAt, LocalDateTime modifiedAt, LocalDateTime deletedAt) {
         return TempCoupleQuestion.builder()
                 .id(id)
                 .question(question)
                 .memberId(memberId)
                 .answer(answer)
+                .coupleQuestionState(coupleQuestionState)
                 .createdAt(createdAt)
                 .modifiedAt(modifiedAt)
                 .deletedAt(deletedAt)

--- a/src/main/java/makeus/cmc/malmo/domain/model/question/TempCoupleQuestion.java
+++ b/src/main/java/makeus/cmc/malmo/domain/model/question/TempCoupleQuestion.java
@@ -37,4 +37,16 @@ public class TempCoupleQuestion {
     public void answerQuestion(String answer) {
         this.answer = answer;
     }
+
+    public static TempCoupleQuestion from(Long id, Question question, MemberId memberId, String answer, LocalDateTime createdAt, LocalDateTime modifiedAt, LocalDateTime deletedAt) {
+        return TempCoupleQuestion.builder()
+                .id(id)
+                .question(question)
+                .memberId(memberId)
+                .answer(answer)
+                .createdAt(createdAt)
+                .modifiedAt(modifiedAt)
+                .deletedAt(deletedAt)
+                .build();
+    }
 }

--- a/src/main/java/makeus/cmc/malmo/domain/model/question/TempCoupleQuestion.java
+++ b/src/main/java/makeus/cmc/malmo/domain/model/question/TempCoupleQuestion.java
@@ -16,7 +16,6 @@ public class TempCoupleQuestion {
     private Long id;
     private Question question;
     private MemberId memberId;
-    private CoupleQuestionState coupleQuestionState;
     private String answer;
 
     // BaseTimeEntity fields
@@ -24,7 +23,18 @@ public class TempCoupleQuestion {
     private LocalDateTime modifiedAt;
     private LocalDateTime deletedAt;
 
+    public static TempCoupleQuestion create(MemberId memberId, Question question) {
+        return TempCoupleQuestion.builder()
+                .question(question)
+                .memberId(memberId)
+                .build();
+    }
+
     public boolean isAnswered() {
         return answer != null && !answer.isEmpty();
+    }
+
+    public void answerQuestion(String answer) {
+        this.answer = answer;
     }
 }

--- a/src/main/java/makeus/cmc/malmo/domain/service/CoupleDomainService.java
+++ b/src/main/java/makeus/cmc/malmo/domain/service/CoupleDomainService.java
@@ -2,6 +2,7 @@ package makeus.cmc.malmo.domain.service;
 
 import lombok.RequiredArgsConstructor;
 import makeus.cmc.malmo.domain.model.couple.Couple;
+import makeus.cmc.malmo.domain.value.id.CoupleId;
 import makeus.cmc.malmo.domain.value.id.MemberId;
 import makeus.cmc.malmo.domain.value.state.CoupleState;
 import org.springframework.stereotype.Service;
@@ -21,6 +22,10 @@ public class CoupleDomainService {
                 startLoveDate,
                 CoupleState.ALIVE
         );
+    }
+
+    public CoupleId getCoupleIdByMemberId(MemberId memberId) {
+        return null;
     }
 
 }

--- a/src/main/java/makeus/cmc/malmo/domain/service/CoupleDomainService.java
+++ b/src/main/java/makeus/cmc/malmo/domain/service/CoupleDomainService.java
@@ -1,6 +1,7 @@
 package makeus.cmc.malmo.domain.service;
 
 import lombok.RequiredArgsConstructor;
+import makeus.cmc.malmo.application.port.out.LoadCouplePort;
 import makeus.cmc.malmo.domain.model.couple.Couple;
 import makeus.cmc.malmo.domain.value.id.CoupleId;
 import makeus.cmc.malmo.domain.value.id.MemberId;
@@ -15,6 +16,8 @@ import java.time.LocalDate;
 @RequiredArgsConstructor
 public class CoupleDomainService {
 
+    private final LoadCouplePort loadCouplePort;
+
     public Couple createCoupleByInviteCode(MemberId memberId, MemberId partnerId, LocalDate startLoveDate) {
         return Couple.createCouple(
                 memberId.getValue(),
@@ -25,7 +28,7 @@ public class CoupleDomainService {
     }
 
     public CoupleId getCoupleIdByMemberId(MemberId memberId) {
-        return null;
+        return loadCouplePort.loadCoupleIdByMemberId(memberId);
     }
 
 }

--- a/src/main/java/makeus/cmc/malmo/domain/service/CoupleQuestionDomainService.java
+++ b/src/main/java/makeus/cmc/malmo/domain/service/CoupleQuestionDomainService.java
@@ -161,6 +161,8 @@ public class CoupleQuestionDomainService {
         boolean memberAnswered = loadTempCoupleQuestionPort.loadTempCoupleQuestionByMemberId(memberId)
                 .filter(TempCoupleQuestion::isAnswered)
                 .map(tempCoupleQuestion -> {
+                    tempCoupleQuestion.usedForCoupleQuestion();
+                    saveTempCoupleQuestionPort.saveTempCoupleQuestion(tempCoupleQuestion);
                     MemberAnswer memberAnswer = savedCoupleQuestion.createMemberAnswer(coupleMemberId, tempCoupleQuestion.getAnswer());
                     saveMemberAnswerPort.saveMemberAnswer(memberAnswer);
                     return true;
@@ -170,6 +172,8 @@ public class CoupleQuestionDomainService {
         boolean partnerAnswered = loadTempCoupleQuestionPort.loadTempCoupleQuestionByMemberId(partnerId)
                 .filter(TempCoupleQuestion::isAnswered)
                 .map(tempCoupleQuestion -> {
+                    tempCoupleQuestion.usedForCoupleQuestion();
+                    saveTempCoupleQuestionPort.saveTempCoupleQuestion(tempCoupleQuestion);
                     MemberAnswer memberAnswer = savedCoupleQuestion.createMemberAnswer(couplePartnerId, tempCoupleQuestion.getAnswer());
                     saveMemberAnswerPort.saveMemberAnswer(memberAnswer);
                     return true;

--- a/src/main/java/makeus/cmc/malmo/domain/service/CoupleQuestionDomainService.java
+++ b/src/main/java/makeus/cmc/malmo/domain/service/CoupleQuestionDomainService.java
@@ -1,0 +1,57 @@
+package makeus.cmc.malmo.domain.service;
+
+import lombok.Data;
+import lombok.Getter;
+import makeus.cmc.malmo.domain.model.question.CoupleQuestion;
+import makeus.cmc.malmo.domain.model.question.Question;
+import makeus.cmc.malmo.domain.model.question.TempCoupleQuestion;
+import makeus.cmc.malmo.domain.value.id.CoupleId;
+import makeus.cmc.malmo.domain.value.id.MemberId;
+import makeus.cmc.malmo.domain.value.state.CoupleQuestionState;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Service
+public class CoupleQuestionDomainService {
+
+    public QuestionRepositoryDto getMaxLevelQuestion(CoupleId coupleId) {
+        return null;
+    }
+
+    public TempCoupleQuestion getTempCoupleQuestion(MemberId memberId) {
+        return null;
+    }
+
+    @Transactional
+    public CoupleQuestion createNextCoupleQuestion(CoupleId coupleId, int level) {
+        return null;
+    }
+
+    @Data
+    public class QuestionRepositoryDto {
+        private Long id;
+        private String title;
+        private String content;
+        private int level;
+        private CoupleId coupleId;
+        private CoupleQuestionState coupleQuestionState;
+        private LocalDateTime bothAnsweredAt;
+        private boolean meAnswered;
+        private boolean partnerAnswered;
+        private LocalDateTime createdAt;
+    }
+
+
+    public boolean needsNextQuestion(LocalDateTime bothAnsweredAt) {
+        if (bothAnsweredAt == null) {
+            return false;
+        }
+
+        LocalDate yesterday = LocalDateTime.now().minusDays(1).toLocalDate();
+
+        return bothAnsweredAt.toLocalDate().equals(yesterday);
+    }
+}

--- a/src/main/java/makeus/cmc/malmo/domain/service/CoupleQuestionDomainService.java
+++ b/src/main/java/makeus/cmc/malmo/domain/service/CoupleQuestionDomainService.java
@@ -1,11 +1,14 @@
 package makeus.cmc.malmo.domain.service;
 
+import lombok.Builder;
 import lombok.Data;
 import lombok.Getter;
+import makeus.cmc.malmo.application.port.in.GetQuestionAnswerUseCase;
 import makeus.cmc.malmo.domain.model.question.CoupleQuestion;
 import makeus.cmc.malmo.domain.model.question.Question;
 import makeus.cmc.malmo.domain.model.question.TempCoupleQuestion;
 import makeus.cmc.malmo.domain.value.id.CoupleId;
+import makeus.cmc.malmo.domain.value.id.CoupleQuestionId;
 import makeus.cmc.malmo.domain.value.id.MemberId;
 import makeus.cmc.malmo.domain.value.state.CoupleQuestionState;
 import org.springframework.stereotype.Service;
@@ -34,6 +37,13 @@ public class CoupleQuestionDomainService {
         return null;
     }
 
+    public void validateQuestionOwnership(CoupleQuestionId coupleQuestionId, MemberId memberId) {
+    }
+
+    public AnswersRepositoryDto getQuestionAnswers(CoupleQuestionId coupleQuestionId) {
+        return null;
+    }
+
     @Data
     public class QuestionRepositoryDto {
         private Long id;
@@ -46,6 +56,19 @@ public class CoupleQuestionDomainService {
         private boolean meAnswered;
         private boolean partnerAnswered;
         private LocalDateTime createdAt;
+    }
+
+    @Data
+    public class AnswersRepositoryDto {
+        private AnswerRepositoryDto me;
+        private AnswerRepositoryDto partner;
+    }
+
+    @Data
+    public class AnswerRepositoryDto {
+        private String nickname;
+        private String answer;
+        private boolean updatable;
     }
 
 

--- a/src/main/java/makeus/cmc/malmo/domain/service/CoupleQuestionDomainService.java
+++ b/src/main/java/makeus/cmc/malmo/domain/service/CoupleQuestionDomainService.java
@@ -1,11 +1,7 @@
 package makeus.cmc.malmo.domain.service;
 
-import lombok.Builder;
 import lombok.Data;
-import lombok.Getter;
-import makeus.cmc.malmo.application.port.in.GetQuestionAnswerUseCase;
 import makeus.cmc.malmo.domain.model.question.CoupleQuestion;
-import makeus.cmc.malmo.domain.model.question.Question;
 import makeus.cmc.malmo.domain.model.question.TempCoupleQuestion;
 import makeus.cmc.malmo.domain.value.id.CoupleId;
 import makeus.cmc.malmo.domain.value.id.CoupleQuestionId;
@@ -20,7 +16,11 @@ import java.time.LocalDateTime;
 @Service
 public class CoupleQuestionDomainService {
 
-    public QuestionRepositoryDto getMaxLevelQuestion(CoupleId coupleId) {
+    public CoupleQuestion getMaxLevelQuestion(CoupleId coupleId) {
+        return null;
+    }
+
+    public QuestionRepositoryDto getMaxLevelQuestionDto(CoupleId coupleId) {
         return null;
     }
 
@@ -33,7 +33,7 @@ public class CoupleQuestionDomainService {
         return null;
     }
 
-    public QuestionRepositoryDto getCoupleQuestionByLevel(CoupleId coupleId, int level) {
+    public QuestionRepositoryDto getCoupleQuestionByLevelDto(CoupleId coupleId, int level) {
         return null;
     }
 
@@ -42,6 +42,35 @@ public class CoupleQuestionDomainService {
 
     public AnswersRepositoryDto getQuestionAnswers(CoupleQuestionId coupleQuestionId) {
         return null;
+    }
+
+    @Transactional
+    public void answerQuestion(CoupleQuestion coupleQuestion, MemberId memberId, String answer) {
+
+    }
+
+    @Transactional
+    public void answerQuestion(TempCoupleQuestion coupleQuestion, MemberId memberId, String answer) {
+
+    }
+
+    public long countAnswers(CoupleQuestionId coupleQuestionId) {
+        return 0;
+    }
+
+    @Transactional
+    public void updateQuestionComplete(CoupleQuestion coupleQuestion) {
+
+    }
+
+    @Transactional
+    public void updateAnswer(CoupleQuestion coupleQuestion, MemberId memberId, String answer) {
+
+    }
+
+    @Transactional
+    public void updateAnswer(TempCoupleQuestion coupleQuestion, MemberId memberId, String answer) {
+
     }
 
     @Data

--- a/src/main/java/makeus/cmc/malmo/domain/service/CoupleQuestionDomainService.java
+++ b/src/main/java/makeus/cmc/malmo/domain/service/CoupleQuestionDomainService.java
@@ -30,6 +30,10 @@ public class CoupleQuestionDomainService {
         return null;
     }
 
+    public QuestionRepositoryDto getCoupleQuestionByLevel(CoupleId coupleId, int level) {
+        return null;
+    }
+
     @Data
     public class QuestionRepositoryDto {
         private Long id;

--- a/src/main/java/makeus/cmc/malmo/domain/service/CoupleQuestionDomainService.java
+++ b/src/main/java/makeus/cmc/malmo/domain/service/CoupleQuestionDomainService.java
@@ -82,9 +82,9 @@ public class CoupleQuestionDomainService {
         }
     }
 
-    public MemberAnswersDto getQuestionAnswers(CoupleQuestionId coupleQuestionId) {
-        return loadMemberAnswerPort.getQuestionAnswers(coupleQuestionId)
-                .orElse(new MemberAnswersDto());
+    public MemberAnswersDto getQuestionAnswers(MemberId memberId, CoupleQuestionId coupleQuestionId) {
+        return loadMemberAnswerPort.getQuestionAnswers(memberId, coupleQuestionId)
+                .orElse(new MemberAnswersDto(null, null));
     }
 
     @Transactional
@@ -157,13 +157,15 @@ public class CoupleQuestionDomainService {
     }
 
     @Data
-    public class MemberAnswersDto {
+    @Builder
+    public static class MemberAnswersDto {
         private AnswerDto me;
         private AnswerDto partner;
     }
 
     @Data
-    public class AnswerDto {
+    @Builder
+    public static class AnswerDto {
         private String nickname;
         private String answer;
         private boolean updatable;

--- a/src/main/java/makeus/cmc/malmo/domain/service/CoupleQuestionDomainService.java
+++ b/src/main/java/makeus/cmc/malmo/domain/service/CoupleQuestionDomainService.java
@@ -1,9 +1,17 @@
 package makeus.cmc.malmo.domain.service;
 
 import lombok.Data;
+import lombok.RequiredArgsConstructor;
+import makeus.cmc.malmo.application.port.out.*;
+import makeus.cmc.malmo.domain.exception.CoupleQuestionNotFoundException;
+import makeus.cmc.malmo.domain.exception.MemberAccessDeniedException;
+import makeus.cmc.malmo.domain.exception.QuestionNotFoundException;
 import makeus.cmc.malmo.domain.model.question.CoupleQuestion;
+import makeus.cmc.malmo.domain.model.question.MemberAnswer;
+import makeus.cmc.malmo.domain.model.question.Question;
 import makeus.cmc.malmo.domain.model.question.TempCoupleQuestion;
 import makeus.cmc.malmo.domain.value.id.CoupleId;
+import makeus.cmc.malmo.domain.value.id.CoupleMemberId;
 import makeus.cmc.malmo.domain.value.id.CoupleQuestionId;
 import makeus.cmc.malmo.domain.value.id.MemberId;
 import makeus.cmc.malmo.domain.value.state.CoupleQuestionState;
@@ -13,68 +21,126 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
+@RequiredArgsConstructor
 @Service
 public class CoupleQuestionDomainService {
 
+    private final LoadCoupleQuestionPort loadCoupleQuestionPort;
+    private final LoadTempCoupleQuestionPort loadTempCoupleQuestionPort;
+    private final LoadQuestionPort loadQuestionPort;
+    private final LoadMemberAnswerPort loadMemberAnswerPort;
+    private final LoadCouplePort loadCouplePort;
+
+    private final SaveCoupleQuestionPort saveCoupleQuestionPort;
+    private final SaveTempCoupleQuestionPort saveTempCoupleQuestionPort;
+
+    public static final int FIRST_QUESTION_LEVEL = 1;
+
     public CoupleQuestion getMaxLevelQuestion(CoupleId coupleId) {
-        return null;
+        return loadCoupleQuestionPort.loadMaxLevelCoupleQuestion(coupleId)
+                .orElseThrow(CoupleQuestionNotFoundException::new);
     }
 
-    public QuestionRepositoryDto getMaxLevelQuestionDto(CoupleId coupleId) {
-        return null;
+    public CoupleQuestionDto getMaxLevelQuestionDto(CoupleId coupleId) {
+        return loadCoupleQuestionPort.getMaxLevelQuestionDto(coupleId)
+                .orElseThrow(CoupleQuestionNotFoundException::new);
+    }
+
+    public CoupleQuestionDto getCoupleQuestionDtoByLevel(CoupleId coupleId, int level) {
+        return loadCoupleQuestionPort.getCoupleQuestionDtoByLevel(coupleId, level)
+                .orElseThrow(CoupleQuestionNotFoundException::new);
     }
 
     public TempCoupleQuestion getTempCoupleQuestion(MemberId memberId) {
-        return null;
+        return loadTempCoupleQuestionPort.loadTempCoupleQuestionByMemberId(memberId)
+                .orElseGet(() -> {
+                            Question question = loadQuestionPort.loadQuestionByLevel(FIRST_QUESTION_LEVEL)
+                                    .orElseThrow(QuestionNotFoundException::new);
+                            TempCoupleQuestion tempCoupleQuestion = TempCoupleQuestion.create(memberId, question);
+                            return saveTempCoupleQuestionPort.saveTempCoupleQuestion(tempCoupleQuestion);
+                        }
+                );
     }
 
     @Transactional
-    public CoupleQuestion createNextCoupleQuestion(CoupleId coupleId, int level) {
-        return null;
+    public CoupleQuestion createNextCoupleQuestion(CoupleId coupleId, int nowLevel) {
+        Question nextQuestion = loadQuestionPort.loadQuestionByLevel(nowLevel + 1)
+                .orElseThrow(QuestionNotFoundException::new);
+        CoupleQuestion coupleQuestion = CoupleQuestion.createCoupleQuestion(nextQuestion, coupleId);
+
+        return saveCoupleQuestionPort.saveCoupleQuestion(coupleQuestion);
     }
 
-    public QuestionRepositoryDto getCoupleQuestionByLevelDto(CoupleId coupleId, int level) {
-        return null;
+    public void validateQuestionOwnership(CoupleQuestionId coupleQuestionId, CoupleId coupleId) {
+        CoupleQuestion coupleQuestion = loadCoupleQuestionPort.loadCoupleQuestionById(coupleQuestionId)
+                .orElseThrow(CoupleQuestionNotFoundException::new);
+
+        if (!coupleQuestion.isOwnedBy(coupleId)) {
+            throw new MemberAccessDeniedException("이 질문에 대한 권한이 없습니다.");
+        }
     }
 
-    public void validateQuestionOwnership(CoupleQuestionId coupleQuestionId, MemberId memberId) {
-    }
-
-    public AnswersRepositoryDto getQuestionAnswers(CoupleQuestionId coupleQuestionId) {
-        return null;
+    public MemberAnswersDto getQuestionAnswers(CoupleQuestionId coupleQuestionId) {
+        return loadMemberAnswerPort.getQuestionAnswers(coupleQuestionId)
+                .orElse(new MemberAnswersDto());
     }
 
     @Transactional
     public void answerQuestion(CoupleQuestion coupleQuestion, MemberId memberId, String answer) {
-
+        CoupleMemberId coupleMemberId = loadCouplePort.loadCoupleMemberIdByMemberId(memberId);
+        // 이미 답변한 질문인지 확인
+        boolean answered = loadMemberAnswerPort.isMemberAnswered(CoupleQuestionId.of(coupleQuestion.getId()), memberId);
+        if (answered) {
+            throw new MemberAccessDeniedException("이미 답변한 질문입니다.");
+        }
+        MemberAnswer memberAnswer = coupleQuestion.createMemberAnswer(coupleMemberId, answer);
+        saveCoupleQuestionPort.saveMemberAnswer(memberAnswer);
     }
 
     @Transactional
-    public void answerQuestion(TempCoupleQuestion coupleQuestion, MemberId memberId, String answer) {
+    public void answerQuestion(TempCoupleQuestion coupleQuestion, String answer) {
+        if (coupleQuestion.isAnswered()) {
+            throw new MemberAccessDeniedException("이미 답변한 질문입니다.");
+        }
 
+        coupleQuestion.answerQuestion(answer);
+        saveTempCoupleQuestionPort.saveTempCoupleQuestion(coupleQuestion);
     }
 
     public long countAnswers(CoupleQuestionId coupleQuestionId) {
-        return 0;
+        return loadMemberAnswerPort.countAnswers(coupleQuestionId);
     }
 
     @Transactional
     public void updateQuestionComplete(CoupleQuestion coupleQuestion) {
-
+        coupleQuestion.complete();
+        saveCoupleQuestionPort.saveCoupleQuestion(coupleQuestion);
     }
 
     @Transactional
     public void updateAnswer(CoupleQuestion coupleQuestion, MemberId memberId, String answer) {
+        if (!coupleQuestion.isUpdatable()) {
+            throw new MemberAccessDeniedException("이미 답변이 완료된 질문입니다.");
+        }
+        MemberAnswer memberAnswer = loadMemberAnswerPort.getMemberAnswer(CoupleQuestionId.of(coupleQuestion.getId()), memberId)
+                .orElseThrow(() -> new MemberAccessDeniedException("답변이 존재하지 않습니다."));
 
+        memberAnswer.updateAnswer(answer);
+        saveCoupleQuestionPort.saveMemberAnswer(memberAnswer);
     }
 
     @Transactional
-    public void updateAnswer(TempCoupleQuestion coupleQuestion, MemberId memberId, String answer) {
+    public void updateAnswer(TempCoupleQuestion coupleQuestion, String answer) {
+        if (!coupleQuestion.isAnswered()) {
+            throw new MemberAccessDeniedException("답변이 완료되지 않은 질문입니다.");
+        }
 
+        coupleQuestion.answerQuestion(answer);
+        saveTempCoupleQuestionPort.saveTempCoupleQuestion(coupleQuestion);
     }
 
     @Data
-    public class QuestionRepositoryDto {
+    public class CoupleQuestionDto {
         private Long id;
         private String title;
         private String content;
@@ -88,13 +154,13 @@ public class CoupleQuestionDomainService {
     }
 
     @Data
-    public class AnswersRepositoryDto {
-        private AnswerRepositoryDto me;
-        private AnswerRepositoryDto partner;
+    public class MemberAnswersDto {
+        private AnswerDto me;
+        private AnswerDto partner;
     }
 
     @Data
-    public class AnswerRepositoryDto {
+    public class AnswerDto {
         private String nickname;
         private String answer;
         private boolean updatable;

--- a/src/main/java/makeus/cmc/malmo/domain/service/CoupleQuestionDomainService.java
+++ b/src/main/java/makeus/cmc/malmo/domain/service/CoupleQuestionDomainService.java
@@ -1,5 +1,6 @@
 package makeus.cmc.malmo.domain.service;
 
+import lombok.Builder;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
 import makeus.cmc.malmo.application.port.out.*;
@@ -41,13 +42,13 @@ public class CoupleQuestionDomainService {
                 .orElseThrow(CoupleQuestionNotFoundException::new);
     }
 
-    public CoupleQuestionDto getMaxLevelQuestionDto(CoupleId coupleId) {
-        return loadCoupleQuestionPort.getMaxLevelQuestionDto(coupleId)
+    public CoupleQuestionDto getMaxLevelQuestionDto(MemberId memberId, CoupleId coupleId) {
+        return loadCoupleQuestionPort.getMaxLevelQuestionDto(memberId, coupleId)
                 .orElseThrow(CoupleQuestionNotFoundException::new);
     }
 
-    public CoupleQuestionDto getCoupleQuestionDtoByLevel(CoupleId coupleId, int level) {
-        return loadCoupleQuestionPort.getCoupleQuestionDtoByLevel(coupleId, level)
+    public CoupleQuestionDto getCoupleQuestionDtoByLevel(MemberId memberId, CoupleId coupleId, int level) {
+        return loadCoupleQuestionPort.getCoupleQuestionDtoByLevel(memberId, coupleId, level)
                 .orElseThrow(CoupleQuestionNotFoundException::new);
     }
 
@@ -140,7 +141,8 @@ public class CoupleQuestionDomainService {
     }
 
     @Data
-    public class CoupleQuestionDto {
+    @Builder
+    public static class CoupleQuestionDto {
         private Long id;
         private String title;
         private String content;

--- a/src/main/java/makeus/cmc/malmo/domain/service/CoupleQuestionDomainService.java
+++ b/src/main/java/makeus/cmc/malmo/domain/service/CoupleQuestionDomainService.java
@@ -34,6 +34,7 @@ public class CoupleQuestionDomainService {
 
     private final SaveCoupleQuestionPort saveCoupleQuestionPort;
     private final SaveTempCoupleQuestionPort saveTempCoupleQuestionPort;
+    private final SaveMemberAnswerPort saveMemberAnswerPort;
 
     public static final int FIRST_QUESTION_LEVEL = 1;
 
@@ -95,7 +96,7 @@ public class CoupleQuestionDomainService {
             throw new MemberAccessDeniedException("이미 답변한 질문입니다.");
         }
         MemberAnswer memberAnswer = coupleQuestion.createMemberAnswer(coupleMemberId, answer);
-        saveCoupleQuestionPort.saveMemberAnswer(memberAnswer);
+        saveMemberAnswerPort.saveMemberAnswer(memberAnswer);
     }
 
     @Transactional
@@ -127,7 +128,7 @@ public class CoupleQuestionDomainService {
                 .orElseThrow(() -> new MemberAccessDeniedException("답변이 존재하지 않습니다."));
 
         memberAnswer.updateAnswer(answer);
-        saveCoupleQuestionPort.saveMemberAnswer(memberAnswer);
+        saveMemberAnswerPort.saveMemberAnswer(memberAnswer);
     }
 
     @Transactional

--- a/src/main/java/makeus/cmc/malmo/domain/service/MemberDomainValidationService.java
+++ b/src/main/java/makeus/cmc/malmo/domain/service/MemberDomainValidationService.java
@@ -2,7 +2,7 @@ package makeus.cmc.malmo.domain.service;
 
 import lombok.RequiredArgsConstructor;
 import makeus.cmc.malmo.application.port.out.ValidateMemberPort;
-import makeus.cmc.malmo.domain.NotCoupleMemberException;
+import makeus.cmc.malmo.domain.exception.NotCoupleMemberException;
 import makeus.cmc.malmo.domain.value.id.MemberId;
 import org.springframework.stereotype.Component;
 

--- a/src/main/java/makeus/cmc/malmo/domain/value/id/CoupleMemberId.java
+++ b/src/main/java/makeus/cmc/malmo/domain/value/id/CoupleMemberId.java
@@ -1,0 +1,12 @@
+package makeus.cmc.malmo.domain.value.id;
+
+import lombok.Value;
+
+@Value
+public class CoupleMemberId {
+    Long value;
+
+    public static CoupleMemberId of(Long value) {
+        return new CoupleMemberId(value);
+    }
+}

--- a/src/main/java/makeus/cmc/malmo/domain/value/id/CoupleQuestionId.java
+++ b/src/main/java/makeus/cmc/malmo/domain/value/id/CoupleQuestionId.java
@@ -1,0 +1,12 @@
+package makeus.cmc.malmo.domain.value.id;
+
+import lombok.Value;
+
+@Value
+public class CoupleQuestionId {
+    Long value;
+
+    public static CoupleQuestionId of(Long value) {
+        return new CoupleQuestionId(value);
+    }
+}

--- a/src/main/java/makeus/cmc/malmo/domain/value/id/QuestionId.java
+++ b/src/main/java/makeus/cmc/malmo/domain/value/id/QuestionId.java
@@ -1,0 +1,12 @@
+package makeus.cmc.malmo.domain.value.id;
+
+import lombok.Value;
+
+@Value
+public class QuestionId {
+    Long value;
+
+    public static QuestionId of(Long value) {
+        return new QuestionId(value);
+    }
+}

--- a/src/main/java/makeus/cmc/malmo/domain/value/state/CoupleQuestionState.java
+++ b/src/main/java/makeus/cmc/malmo/domain/value/state/CoupleQuestionState.java
@@ -1,5 +1,5 @@
 package makeus.cmc.malmo.domain.value.state;
 
 public enum CoupleQuestionState {
-    ALIVE, COMPLETED, DELETED
+    ALIVE, COMPLETED, OUTDATED, DELETED
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> - #MM-45

## 📝 작업 내용

> - 오늘의 질문 조회, 질문 답변, 답변 조회 API 구현
> - 커플 연결 시 연결 전 기존 답변 연동 기능 추가
> - 재연결 시 기존 임시 답변 사용을 방지하기 위해 상태 추가
