### PR TITLE
채팅 API 누락 데이터 추가

### DIFF
--- a/src/main/java/makeus/cmc/malmo/adaptor/in/web/controller/ChatRoomController.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/in/web/controller/ChatRoomController.java
@@ -17,6 +17,8 @@ import makeus.cmc.malmo.application.port.in.DeleteChatRoomUseCase;
 import makeus.cmc.malmo.application.port.in.GetChatRoomListUseCase;
 import makeus.cmc.malmo.application.port.in.GetChatRoomMessagesUseCase;
 import makeus.cmc.malmo.application.port.in.GetChatRoomSummaryUseCase;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.web.bind.annotation.*;
@@ -70,18 +72,18 @@ public class ChatRoomController {
     @ApiCommonResponses.RequireAuth
     @GetMapping
     public BaseResponse<BaseListResponse<GetChatRoomListUseCase.GetChatRoomResponse>> getChatRoomList(
-            @RequestParam(value = "page", defaultValue = "0") int page,
-            @RequestParam(value = "size", defaultValue = "10") int size,
+            @PageableDefault(page = 0, size = 10) Pageable pageable,
             @RequestParam(value = "keyword", defaultValue = "") String keyword,
             @AuthenticationPrincipal User user) {
         GetChatRoomListUseCase.GetChatRoomListCommand command = GetChatRoomListUseCase.GetChatRoomListCommand.builder()
                 .userId(Long.valueOf(user.getUsername()))
                 .keyword(keyword)
-                .page(page)
-                .size(size)
+                .pageable(pageable)
                 .build();
 
-        return BaseListResponse.success(getChatRoomListUseCase.getChatRoomList(command).getChatRoomList());
+        GetChatRoomListUseCase.GetChatRoomListResponse response = getChatRoomListUseCase.getChatRoomList(command);
+
+        return BaseListResponse.success(response.getChatRoomList(), response.getTotalCount());
     }
 
     @Operation(

--- a/src/main/java/makeus/cmc/malmo/adaptor/in/web/controller/ChatRoomController.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/in/web/controller/ChatRoomController.java
@@ -100,17 +100,16 @@ public class ChatRoomController {
     @ApiCommonResponses.OnlyOwner
     @GetMapping("/{chatRoomId}/messages")
     public BaseResponse<BaseListResponse<GetChatRoomMessagesUseCase.ChatRoomMessageDto>> getChatRoomMessages(
-            @RequestParam(value = "page", defaultValue = "0") int page,
-            @RequestParam(value = "size", defaultValue = "10") int size,
+            @PageableDefault(page = 0, size = 10) Pageable pageable,
             @AuthenticationPrincipal User user, @PathVariable Long chatRoomId) {
         GetChatRoomMessagesUseCase.GetChatRoomMessagesCommand command = GetChatRoomMessagesUseCase.GetChatRoomMessagesCommand.builder()
                 .userId(Long.valueOf(user.getUsername()))
                 .chatRoomId(chatRoomId)
-                .page(page)
-                .size(size)
+                .pageable(pageable)
                 .build();
 
-        return BaseListResponse.success(getChatRoomMessagesUseCase.getChatRoomMessages(command).getMessages());
+        GetChatRoomMessagesUseCase.GetCurrentChatRoomMessagesResponse response = getChatRoomMessagesUseCase.getChatRoomMessages(command);
+        return BaseListResponse.success(response.getMessages(), response.getTotalCount());
     }
 
     @Operation(

--- a/src/main/java/makeus/cmc/malmo/adaptor/in/web/controller/CurrentChatController.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/in/web/controller/CurrentChatController.java
@@ -20,6 +20,8 @@ import makeus.cmc.malmo.application.port.in.CompleteChatRoomUseCase;
 import makeus.cmc.malmo.application.port.in.GetCurrentChatRoomMessagesUseCase;
 import makeus.cmc.malmo.application.port.in.GetCurrentChatRoomUseCase;
 import makeus.cmc.malmo.application.port.in.SendChatMessageUseCase;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.web.bind.annotation.*;
@@ -68,17 +70,15 @@ public class CurrentChatController {
     @ApiCommonResponses.RequireAuth
     @GetMapping("/messages")
     public BaseResponse<BaseListResponse<GetCurrentChatRoomMessagesUseCase.ChatRoomMessageDto>> getCurrentChatRoomMessages(
-            @RequestParam(value = "page", defaultValue = "0") int page,
-            @RequestParam(value = "size", defaultValue = "10") int size,
+            @PageableDefault(page = 0, size = 10) Pageable pageable,
             @AuthenticationPrincipal User user) {
         GetCurrentChatRoomMessagesUseCase.GetCurrentChatRoomMessagesCommand command = GetCurrentChatRoomMessagesUseCase.GetCurrentChatRoomMessagesCommand.builder()
                 .userId(Long.valueOf(user.getUsername()))
-                .page(page) // 기본 페이지 0
-                .size(size) // 기본 페이지 크기 20
+                .pageable(pageable)
                 .build();
         GetCurrentChatRoomMessagesUseCase.GetCurrentChatRoomMessagesResponse currentChatRoomMessages = getCurrentChatRoomMessagesUseCase.getCurrentChatRoomMessages(command);
 
-        return BaseListResponse.success(currentChatRoomMessages.getMessages());
+        return BaseListResponse.success(currentChatRoomMessages.getMessages(), currentChatRoomMessages.getTotalCount());
     }
 
     @Operation(

--- a/src/main/java/makeus/cmc/malmo/adaptor/in/web/controller/LoveTypeController.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/in/web/controller/LoveTypeController.java
@@ -42,6 +42,6 @@ public class LoveTypeController {
         GetLoveTypeQuestionsUseCase.LoveTypeQuestionsResponseDto loveTypeQuestions
                 = getLoveTypeQuestionsUseCase.getLoveTypeQuestions();
 
-        return BaseListResponse.success(loveTypeQuestions.getList());
+        return BaseListResponse.success(loveTypeQuestions.getList(), loveTypeQuestions.getTotalCount());
     }
 }

--- a/src/main/java/makeus/cmc/malmo/adaptor/in/web/controller/MemberController.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/in/web/controller/MemberController.java
@@ -134,7 +134,7 @@ public class MemberController {
                 .memberId(Long.valueOf(user.getUsername()))
                 .terms(termsCommands)
                 .build();
-        return BaseListResponse.success(updateTermsAgreementUseCase.updateTermsAgreement(command).getTerms());
+        return BaseListResponse.success(updateTermsAgreementUseCase.updateTermsAgreement(command).getTerms(), (long) termsCommands.size());
     }
 
     @Operation(

--- a/src/main/java/makeus/cmc/malmo/adaptor/in/web/controller/TermsController.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/in/web/controller/TermsController.java
@@ -36,6 +36,6 @@ public class TermsController {
     @GetMapping("/terms")
     public BaseResponse<BaseListResponse<TermsUseCase.TermsDto>> getTerms() {
         List<TermsUseCase.TermsDto> termsList = termsUseCase.getTerms().getTermsList();
-        return BaseListResponse.success(termsList);
+        return BaseListResponse.success(termsList, (long) termsList.size());
     }
 }

--- a/src/main/java/makeus/cmc/malmo/adaptor/in/web/docs/SwaggerResponses.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/in/web/docs/SwaggerResponses.java
@@ -40,6 +40,9 @@ public class SwaggerResponses {
 
         @Schema(description = "응답 데이터 리스트")
         private List<T> list;
+
+        @Schema(description = "전체 데이터 개수", example = "100")
+        private Long totalCount;
     }
 
     // 로그인 관련 응답

--- a/src/main/java/makeus/cmc/malmo/adaptor/in/web/docs/SwaggerResponses.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/in/web/docs/SwaggerResponses.java
@@ -493,6 +493,8 @@ public class SwaggerResponses {
     public static class GetChatRoomSummaryData {
         @Schema(description = "채팅방의 ID", example = "1")
         private Long chatRoomId;
+        @Schema(description = "채팅방 생성 시간", example = "2025-07-20T10:15:30")
+        private LocalDateTime createdAt;
         @Schema(description = "채팅방 전체 요약", example = "회피형 남자친구의 연락두절 문제")
         private String totalSummary;
         @Schema(description = "채팅방 상황 요약", example = "남자친구는 여사친과 몰래 밥을 먹은 일에 대해 사과하길 회피했다. 이전에도 비슷한 상황이 반복되었고, 베리는 자신의 감정을 과한 것으로 여기며 소통에 어려움을 경험했다.")

--- a/src/main/java/makeus/cmc/malmo/adaptor/in/web/dto/BaseListResponse.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/in/web/dto/BaseListResponse.java
@@ -15,22 +15,23 @@ public class BaseListResponse<T> {
     private int size;
     private Integer page;
     private List<T> list;
+    private Long totalCount;
 
-    public static <T> BaseResponse<BaseListResponse<T>> success(List<T> data, int page) {
+    public static <T> BaseResponse<BaseListResponse<T>> success(List<T> data, int page, Long totalCount) {
         return new BaseResponse<>(
                 MDC.get("request_id"),
                 true,
                 "요청이 성공적으로 처리되었습니다.",
-                new BaseListResponse<>(data.size(), page, data)
+                new BaseListResponse<>(data.size(), page, data, totalCount)
         );
     }
 
-    public static <T> BaseResponse<BaseListResponse<T>> success(List<T> data) {
+    public static <T> BaseResponse<BaseListResponse<T>> success(List<T> data, Long totalCount) {
         return new BaseResponse<>(
                 MDC.get("request_id"),
                 true,
                 "요청이 성공적으로 처리되었습니다.",
-                new BaseListResponse<>(data.size(), null, data)
+                new BaseListResponse<>(data.size(), null, data, totalCount)
         );
     }
 }

--- a/src/main/java/makeus/cmc/malmo/adaptor/out/OpenAiApiClient.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/out/OpenAiApiClient.java
@@ -109,17 +109,20 @@ public class OpenAiApiClient implements RequestChatApiPort {
         Request request = createRequest(body);
 
         try (Response response = client.newCall(request).execute()) {
-            log.info("OpenAI API response code: {}, body: {}", response.code(), response.body().string());
+            log.info("OpenAI API response code: {}", response.code());
 
             if (!response.isSuccessful()) {
+                log.error("OpenAI API request failed with code: {}", response.code());
                 throw new OpenAiRequestException("OpenAI API request failed with code: " + response.code());
             }
 
             String data = response.body().string();
+            log.info("OpenAI API response data: {}", extractContent(data));
             return extractContent(data);
         } catch (IOException e) {
             throw new OpenAiRequestException("Failed to connect to OpenAI API");
         } catch (Exception e) {
+            e.printStackTrace();
             throw new OpenAiRequestException("Error processing OpenAI API response");
         }
     }

--- a/src/main/java/makeus/cmc/malmo/adaptor/out/OpenAiApiClient.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/out/OpenAiApiClient.java
@@ -109,6 +109,8 @@ public class OpenAiApiClient implements RequestChatApiPort {
         Request request = createRequest(body);
 
         try (Response response = client.newCall(request).execute()) {
+            log.info("OpenAI API response code: {}, body: {}", response.code(), response.body().string());
+
             if (!response.isSuccessful()) {
                 throw new OpenAiRequestException("OpenAI API request failed with code: " + response.code());
             }

--- a/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/ChatRoomPersistenceAdapter.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/ChatRoomPersistenceAdapter.java
@@ -12,6 +12,9 @@ import makeus.cmc.malmo.domain.model.chat.ChatMessage;
 import makeus.cmc.malmo.domain.model.chat.ChatRoom;
 import makeus.cmc.malmo.domain.value.id.ChatRoomId;
 import makeus.cmc.malmo.domain.value.id.MemberId;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -78,11 +81,11 @@ public class ChatRoomPersistenceAdapter
     }
 
     @Override
-    public List<ChatRoom> loadAliveChatRoomsByMemberId(MemberId memberId, String keyword, int page, int size) {
-        return chatRoomRepository.loadChatRoomListByMemberId(memberId.getValue(), keyword, page, size)
-                .stream()
-                .map(chatRoomMapper::toDomain)
-                .toList();
+    public Page<ChatRoom> loadAliveChatRoomsByMemberId(MemberId memberId, String keyword, Pageable pageable) {
+        Page<ChatRoomEntity> chatRoomEntities = chatRoomRepository.loadChatRoomListByMemberId(memberId.getValue(), keyword, pageable);
+        return new PageImpl<>(chatRoomEntities.stream().map(chatRoomMapper::toDomain).toList(),
+                pageable,
+                chatRoomEntities.getTotalElements());
     }
 
     @Override

--- a/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/ChatRoomPersistenceAdapter.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/ChatRoomPersistenceAdapter.java
@@ -31,13 +31,13 @@ public class ChatRoomPersistenceAdapter
     private final ChatMessageMapper chatMessageMapper;
 
     @Override
-    public List<ChatRoomMessageRepositoryDto> loadMessagesDto(ChatRoomId chatRoomId, int page, int size) {
-        return chatMessageRepository.loadCurrentMessagesDto(chatRoomId.getValue(), page, size);
+    public Page<ChatRoomMessageRepositoryDto> loadMessagesDto(ChatRoomId chatRoomId, Pageable pageable) {
+        return chatMessageRepository.loadCurrentMessagesDto(chatRoomId.getValue(), pageable);
     }
 
     @Override
-    public List<ChatRoomMessageRepositoryDto> loadMessagesDtoAsc(ChatRoomId chatRoomId, int page, int size) {
-        return chatMessageRepository.loadCurrentMessagesDtoAsc(chatRoomId.getValue(), page, size);
+    public Page<ChatRoomMessageRepositoryDto> loadMessagesDtoAsc(ChatRoomId chatRoomId, Pageable pageable) {
+        return chatMessageRepository.loadCurrentMessagesDtoAsc(chatRoomId.getValue(), pageable);
     }
 
     @Override

--- a/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/repository/custom/ChatMessageRepositoryCustom.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/repository/custom/ChatMessageRepositoryCustom.java
@@ -1,10 +1,12 @@
 package makeus.cmc.malmo.adaptor.out.persistence.repository.custom;
 
 import makeus.cmc.malmo.application.port.out.LoadMessagesPort;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
 public interface ChatMessageRepositoryCustom {
-    List<LoadMessagesPort.ChatRoomMessageRepositoryDto> loadCurrentMessagesDto(Long chatRoomId, int page, int size);
-    List<LoadMessagesPort.ChatRoomMessageRepositoryDto> loadCurrentMessagesDtoAsc(Long chatRoomId, int page, int size);
+    Page<LoadMessagesPort.ChatRoomMessageRepositoryDto> loadCurrentMessagesDto(Long chatRoomId, Pageable pageable);
+    Page<LoadMessagesPort.ChatRoomMessageRepositoryDto> loadCurrentMessagesDtoAsc(Long chatRoomId, Pageable pageable);
 }

--- a/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/repository/custom/ChatRoomRepositoryCustom.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/repository/custom/ChatRoomRepositoryCustom.java
@@ -3,11 +3,13 @@ package makeus.cmc.malmo.adaptor.out.persistence.repository.custom;
 import makeus.cmc.malmo.adaptor.out.persistence.entity.chat.ChatRoomEntity;
 import makeus.cmc.malmo.application.port.out.LoadMessagesPort;
 import makeus.cmc.malmo.domain.model.chat.ChatRoom;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
 public interface ChatRoomRepositoryCustom {
-    List<ChatRoomEntity> loadChatRoomListByMemberId(Long memberId, String keyword, int page, int size);
+    Page<ChatRoomEntity> loadChatRoomListByMemberId(Long memberId, String keyword, Pageable pageable);
 
     boolean isMemberOwnerOfChatRooms(Long memberId, List<Long> chatRoomIds);
 

--- a/src/main/java/makeus/cmc/malmo/application/port/in/GetChatRoomListUseCase.java
+++ b/src/main/java/makeus/cmc/malmo/application/port/in/GetChatRoomListUseCase.java
@@ -2,6 +2,7 @@ package makeus.cmc.malmo.application.port.in;
 
 import lombok.Builder;
 import lombok.Data;
+import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -15,14 +16,14 @@ public interface GetChatRoomListUseCase {
     class GetChatRoomListCommand {
         private Long userId;
         private String keyword;
-        private Integer page;
-        private Integer size;
+        private Pageable pageable;
     }
 
     @Data
     @Builder
     class GetChatRoomListResponse {
         private List<GetChatRoomResponse> chatRoomList;
+        private Long totalCount;
     }
 
     @Data

--- a/src/main/java/makeus/cmc/malmo/application/port/in/GetChatRoomMessagesUseCase.java
+++ b/src/main/java/makeus/cmc/malmo/application/port/in/GetChatRoomMessagesUseCase.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Data;
 import makeus.cmc.malmo.domain.value.type.SenderType;
+import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -17,14 +18,14 @@ public interface GetChatRoomMessagesUseCase {
     class GetChatRoomMessagesCommand {
         private Long userId;
         private Long chatRoomId;
-        private int page;
-        private int size;
+        private Pageable pageable;
     }
 
     @Data
     @Builder
     class GetCurrentChatRoomMessagesResponse {
         private List<ChatRoomMessageDto> messages;
+        private Long totalCount;
     }
 
     @Data

--- a/src/main/java/makeus/cmc/malmo/application/port/in/GetChatRoomSummaryUseCase.java
+++ b/src/main/java/makeus/cmc/malmo/application/port/in/GetChatRoomSummaryUseCase.java
@@ -3,6 +3,8 @@ package makeus.cmc.malmo.application.port.in;
 import lombok.Builder;
 import lombok.Data;
 
+import java.time.LocalDateTime;
+
 public interface GetChatRoomSummaryUseCase {
 
     GetChatRoomSummaryResponse getChatRoomSummary(GetChatRoomSummaryCommand command);
@@ -18,6 +20,7 @@ public interface GetChatRoomSummaryUseCase {
     @Builder
     class GetChatRoomSummaryResponse {
         private Long chatRoomId;
+        private LocalDateTime createdAt;
         private String totalSummary;
         private String firstSummary;
         private String secondSummary;

--- a/src/main/java/makeus/cmc/malmo/application/port/in/GetCurrentChatRoomMessagesUseCase.java
+++ b/src/main/java/makeus/cmc/malmo/application/port/in/GetCurrentChatRoomMessagesUseCase.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Data;
 import makeus.cmc.malmo.domain.value.type.SenderType;
+import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -16,14 +17,14 @@ public interface GetCurrentChatRoomMessagesUseCase {
     @Builder
     class GetCurrentChatRoomMessagesCommand {
         private Long userId;
-        private int page;
-        private int size;
+        private Pageable pageable;
     }
 
     @Data
     @Builder
     class GetCurrentChatRoomMessagesResponse {
         private List<ChatRoomMessageDto> messages;
+        private Long totalCount;
     }
 
     @Data

--- a/src/main/java/makeus/cmc/malmo/application/port/in/GetLoveTypeQuestionsUseCase.java
+++ b/src/main/java/makeus/cmc/malmo/application/port/in/GetLoveTypeQuestionsUseCase.java
@@ -13,6 +13,7 @@ public interface GetLoveTypeQuestionsUseCase {
     @Builder
     class LoveTypeQuestionsResponseDto {
         private List<LoveTypeQuestionDto> list;
+        private Long totalCount;
     }
 
     @Data

--- a/src/main/java/makeus/cmc/malmo/application/port/out/LoadChatRoomPort.java
+++ b/src/main/java/makeus/cmc/malmo/application/port/out/LoadChatRoomPort.java
@@ -3,6 +3,8 @@ package makeus.cmc.malmo.application.port.out;
 import makeus.cmc.malmo.domain.model.chat.ChatRoom;
 import makeus.cmc.malmo.domain.value.id.ChatRoomId;
 import makeus.cmc.malmo.domain.value.id.MemberId;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 import java.util.Optional;
@@ -12,7 +14,7 @@ public interface LoadChatRoomPort {
     Optional<ChatRoom> loadChatRoomById(ChatRoomId chatRoomId);
     Optional<ChatRoom> loadPausedChatRoomByMemberId(MemberId memberId);
 
-    List<ChatRoom> loadAliveChatRoomsByMemberId(MemberId memberId, String keyword, int page, int size);
+    Page<ChatRoom> loadAliveChatRoomsByMemberId(MemberId memberId, String keyword, Pageable pageable);
 
     boolean isMemberOwnerOfChatRooms(MemberId memberId, List<ChatRoomId> chatRoomIds);
 }

--- a/src/main/java/makeus/cmc/malmo/application/port/out/LoadMessagesPort.java
+++ b/src/main/java/makeus/cmc/malmo/application/port/out/LoadMessagesPort.java
@@ -5,13 +5,15 @@ import lombok.Data;
 import makeus.cmc.malmo.domain.model.chat.ChatMessage;
 import makeus.cmc.malmo.domain.value.id.ChatRoomId;
 import makeus.cmc.malmo.domain.value.type.SenderType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
 public interface LoadMessagesPort {
-    List<ChatRoomMessageRepositoryDto> loadMessagesDto(ChatRoomId chatRoomId, int page, int size);
-    List<ChatRoomMessageRepositoryDto> loadMessagesDtoAsc(ChatRoomId chatRoomId, int page, int size);
+    Page<ChatRoomMessageRepositoryDto> loadMessagesDto(ChatRoomId chatRoomId, Pageable pageable);
+    Page<ChatRoomMessageRepositoryDto> loadMessagesDtoAsc(ChatRoomId chatRoomId, Pageable pageable);
     List<ChatMessage> loadChatRoomMessagesByLevel(ChatRoomId chatRoomId, int level);
 
     @Data

--- a/src/main/java/makeus/cmc/malmo/application/service/ChatRoomService.java
+++ b/src/main/java/makeus/cmc/malmo/application/service/ChatRoomService.java
@@ -75,12 +75,10 @@ public class ChatRoomService
     public GetCurrentChatRoomMessagesResponse getChatRoomMessages(GetChatRoomMessagesCommand command) {
         chatRoomDomainService.validateChatRoomOwnership(MemberId.of(command.getUserId()), ChatRoomId.of(command.getChatRoomId()));
 
-        List<LoadMessagesPort.ChatRoomMessageRepositoryDto> chatMessagesDto = chatMessagesDomainService.getChatMessagesDtoAsc(
-                ChatRoomId.of(command.getChatRoomId()), command.getPage(), command.getSize());
+        Page<LoadMessagesPort.ChatRoomMessageRepositoryDto> result =
+                chatMessagesDomainService.getChatMessagesDtoAsc(ChatRoomId.of(command.getChatRoomId()), command.getPageable());
 
-        List<GetChatRoomMessagesUseCase.ChatRoomMessageDto> list = chatMessagesDto
-                .stream()
-                .map(cm ->
+        List<GetChatRoomMessagesUseCase.ChatRoomMessageDto> list = result.stream().map(cm ->
                         GetChatRoomMessagesUseCase.ChatRoomMessageDto.builder()
                                 .messageId(cm.getMessageId())
                                 .senderType(cm.getSenderType())
@@ -92,6 +90,7 @@ public class ChatRoomService
 
         return GetCurrentChatRoomMessagesResponse.builder()
                 .messages(list)
+                .totalCount(result.getTotalElements())
                 .build();
     }
 

--- a/src/main/java/makeus/cmc/malmo/application/service/ChatRoomService.java
+++ b/src/main/java/makeus/cmc/malmo/application/service/ChatRoomService.java
@@ -9,6 +9,7 @@ import makeus.cmc.malmo.domain.service.ChatMessagesDomainService;
 import makeus.cmc.malmo.domain.service.ChatRoomDomainService;
 import makeus.cmc.malmo.domain.value.id.ChatRoomId;
 import makeus.cmc.malmo.domain.value.id.MemberId;
+import org.springframework.data.domain.Page;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 
@@ -50,11 +51,11 @@ public class ChatRoomService
 
     @Override
     public GetChatRoomListResponse getChatRoomList(GetChatRoomListCommand command) {
-        List<ChatRoom> chatRoomList = chatRoomDomainService.getCompletedChatRoomsByMemberId(
-                MemberId.of(command.getUserId()), command.getKeyword(), command.getPage(), command.getSize()
+        Page<ChatRoom> chatRoomList = chatRoomDomainService.getCompletedChatRoomsByMemberId(
+                MemberId.of(command.getUserId()), command.getKeyword(), command.getPageable()
         );
 
-        List<GetChatRoomResponse> response = chatRoomList.stream()
+        List<GetChatRoomResponse> response = chatRoomList.getContent().stream()
                 .map(chatRoom -> GetChatRoomResponse.builder()
                         .chatRoomId(chatRoom.getId())
                         .totalSummary(chatRoom.getTotalSummary())
@@ -66,6 +67,7 @@ public class ChatRoomService
 
         return GetChatRoomListResponse.builder()
                 .chatRoomList(response)
+                .totalCount(chatRoomList.getTotalElements())
                 .build();
     }
 

--- a/src/main/java/makeus/cmc/malmo/application/service/ChatRoomService.java
+++ b/src/main/java/makeus/cmc/malmo/application/service/ChatRoomService.java
@@ -42,6 +42,7 @@ public class ChatRoomService
 
         return GetChatRoomSummaryResponse.builder()
                 .chatRoomId(chatRoom.getId())
+                .createdAt(chatRoom.getCreatedAt())
                 .totalSummary(totalSummary)
                 .firstSummary(firstSummary)
                 .secondSummary(secondSummary)

--- a/src/main/java/makeus/cmc/malmo/application/service/ChatStreamProcessor.java
+++ b/src/main/java/makeus/cmc/malmo/application/service/ChatStreamProcessor.java
@@ -62,6 +62,9 @@ public class ChatStreamProcessor {
                     if(chunk.contains("OK") && !prompt.isLastPrompt()) {
                         isOkDetected.set(true);
                     } else {
+                        if (chunk.startsWith(" ")) {
+                            chunk = " " + chunk;  // 공백 한 칸을 앞에 추가 (html event stream에서 공백이 제거되는 문제 해결)
+                        }
                         sendSseMessage(memberId, chunk);
                     }
                 },

--- a/src/main/java/makeus/cmc/malmo/application/service/CurrentChatRoomService.java
+++ b/src/main/java/makeus/cmc/malmo/application/service/CurrentChatRoomService.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import makeus.cmc.malmo.application.port.in.CompleteChatRoomUseCase;
 import makeus.cmc.malmo.application.port.in.GetCurrentChatRoomMessagesUseCase;
 import makeus.cmc.malmo.application.port.in.GetCurrentChatRoomUseCase;
+import makeus.cmc.malmo.application.port.out.LoadMessagesPort;
 import makeus.cmc.malmo.domain.model.chat.ChatMessage;
 import makeus.cmc.malmo.domain.model.chat.ChatMessageSummary;
 import makeus.cmc.malmo.domain.model.chat.ChatRoom;
@@ -15,6 +16,7 @@ import makeus.cmc.malmo.domain.service.PromptDomainService;
 import makeus.cmc.malmo.domain.value.id.ChatRoomId;
 import makeus.cmc.malmo.domain.value.id.MemberId;
 import makeus.cmc.malmo.domain.value.type.SenderType;
+import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -50,10 +52,9 @@ public class CurrentChatRoomService
         // 현재 채팅방 가져오기
         ChatRoom currentChatRoom = chatRoomDomainService.getCurrentChatRoomByMemberId(MemberId.of(command.getUserId()));
 
-        List<ChatRoomMessageDto> list = chatMessagesDomainService.getChatMessagesDto(
-                        ChatRoomId.of(currentChatRoom.getId()), command.getPage(), command.getSize())
-                .stream()
-                .map(cm ->
+        Page<LoadMessagesPort.ChatRoomMessageRepositoryDto> result = chatMessagesDomainService.getChatMessagesDto(
+                ChatRoomId.of(currentChatRoom.getId()), command.getPageable());
+        List<ChatRoomMessageDto> list = result.stream().map(cm ->
                         ChatRoomMessageDto.builder()
                                 .messageId(cm.getMessageId())
                                 .senderType(cm.getSenderType())
@@ -65,6 +66,7 @@ public class CurrentChatRoomService
 
         return GetCurrentChatRoomMessagesResponse.builder()
                 .messages(list)
+                .totalCount(result.getTotalElements())
                 .build();
     }
 

--- a/src/main/java/makeus/cmc/malmo/application/service/LoveTypeQuestionService.java
+++ b/src/main/java/makeus/cmc/malmo/application/service/LoveTypeQuestionService.java
@@ -34,6 +34,7 @@ public class LoveTypeQuestionService implements GetLoveTypeQuestionsUseCase {
 
         return LoveTypeQuestionsResponseDto.builder()
                 .list(loveTypeQuestionDtoList)
+                .totalCount((long) loveTypeQuestionDtoList.size())
                 .build();
     }
 }

--- a/src/main/java/makeus/cmc/malmo/domain/service/ChatMessagesDomainService.java
+++ b/src/main/java/makeus/cmc/malmo/domain/service/ChatMessagesDomainService.java
@@ -7,6 +7,8 @@ import makeus.cmc.malmo.application.port.out.SaveChatMessagePort;
 import makeus.cmc.malmo.domain.model.chat.ChatMessage;
 import makeus.cmc.malmo.domain.model.chat.ChatMessageSummary;
 import makeus.cmc.malmo.domain.value.id.ChatRoomId;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,12 +23,12 @@ public class ChatMessagesDomainService {
     private final SaveChatMessagePort saveChatMessagePort;
     private final LoadSummarizedMessages loadSummarizedMessages;
 
-    public List<LoadMessagesPort.ChatRoomMessageRepositoryDto> getChatMessagesDto(ChatRoomId chatRoomId, int page, int size) {
-        return loadMessagesPort.loadMessagesDto(chatRoomId, page, size);
+    public Page<LoadMessagesPort.ChatRoomMessageRepositoryDto> getChatMessagesDto(ChatRoomId chatRoomId, Pageable pageable) {
+        return loadMessagesPort.loadMessagesDto(chatRoomId, pageable);
     }
 
-    public List<LoadMessagesPort.ChatRoomMessageRepositoryDto> getChatMessagesDtoAsc(ChatRoomId chatRoomId, int page, int size) {
-        return loadMessagesPort.loadMessagesDtoAsc(chatRoomId, page, size);
+    public Page<LoadMessagesPort.ChatRoomMessageRepositoryDto> getChatMessagesDtoAsc(ChatRoomId chatRoomId, Pageable pageable) {
+        return loadMessagesPort.loadMessagesDtoAsc(chatRoomId, pageable);
     }
 
     @Transactional

--- a/src/main/java/makeus/cmc/malmo/domain/service/ChatRoomDomainService.java
+++ b/src/main/java/makeus/cmc/malmo/domain/service/ChatRoomDomainService.java
@@ -11,6 +11,8 @@ import makeus.cmc.malmo.domain.model.chat.ChatRoom;
 import makeus.cmc.malmo.domain.model.member.Member;
 import makeus.cmc.malmo.domain.value.id.ChatRoomId;
 import makeus.cmc.malmo.domain.value.id.MemberId;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -88,8 +90,8 @@ public class ChatRoomDomainService {
         return loadChatRoomPort.loadChatRoomById(chatRoomId).orElseThrow(ChatRoomNotFoundException::new);
     }
 
-    public List<ChatRoom> getCompletedChatRoomsByMemberId(MemberId memberId, String keyword, int page, int size) {
-        return loadChatRoomPort.loadAliveChatRoomsByMemberId(memberId, keyword, page, size);
+    public Page<ChatRoom> getCompletedChatRoomsByMemberId(MemberId memberId, String keyword, Pageable pageable) {
+        return loadChatRoomPort.loadAliveChatRoomsByMemberId(memberId, keyword, pageable);
     }
 
     @Transactional


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> FIX

## 📝 작업 내용

> - 모든 리스트 조회에서 totalCount를 반환하도록 변경
> - 채팅 요약에서 발생하는 문제 확인을 위해 로그 추가
> - 채팅 요약 조회에서 생성 시간 데이터를 추가
> - html event stream에서 공백이 제거되는 문제 해결을 위해 공백 중복 추가
