### PR TITLE
[HOTFIX] 질문 무한 생성 버그 해결

### DIFF
--- a/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/repository/custom/CoupleQuestionRepositoryCustomImpl.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/repository/custom/CoupleQuestionRepositoryCustomImpl.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import makeus.cmc.malmo.adaptor.out.persistence.CoupleQuestionPersistenceAdapter;
 import makeus.cmc.malmo.adaptor.out.persistence.entity.question.CoupleQuestionEntity;
 import makeus.cmc.malmo.domain.value.state.CoupleMemberState;
+import makeus.cmc.malmo.domain.value.state.CoupleQuestionState;
 
 import java.util.Optional;
 
@@ -60,7 +61,7 @@ public class CoupleQuestionRepositoryCustomImpl implements CoupleQuestionReposit
                 ))
                 .from(coupleQuestionEntity)
                 .where(coupleQuestionEntity.coupleEntityId.value.eq(coupleId))
-                .orderBy(coupleQuestionEntity.question.level.asc())
+                .orderBy(coupleQuestionEntity.question.level.desc())
                 .limit(1)
                 .fetchOne();
 
@@ -111,7 +112,8 @@ public class CoupleQuestionRepositoryCustomImpl implements CoupleQuestionReposit
                 .join(coupleMemberEntity)
                 .on(coupleMemberEntity.coupleEntityId.value.eq(coupleQuestionEntity.coupleEntityId.value))
                 .where(coupleMemberEntity.memberEntityId.value.eq(memberId)
-                        .and(coupleMemberEntity.coupleMemberState.ne(CoupleMemberState.DELETED)))
+                        .and(coupleMemberEntity.coupleMemberState.ne(CoupleMemberState.DELETED))
+                        .and(coupleQuestionEntity.coupleQuestionState.eq(CoupleQuestionState.COMPLETED)))
                 .fetchOne();
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> - 질문을 조회할 때 마다 무한으로 질문이 생성되는 문제

## 📝 작업 내용

> - 질문 조회 시 가장 높은 단계의 질문을 조회하도록 변경
> - 사용자 정보 조회에서 질문 수를 완료된 질문 수만 count 하도록 변경
