### PR TITLE
OpenAI API 요청을 CompletableFuture 기반의 비동기 로직으로 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,6 +62,9 @@ dependencies {
 	// Redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
+	// WebFlux (Web Client)
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
 }
 
 // QueryDSL Q클래스 생성 경로 설정

--- a/src/main/java/makeus/cmc/malmo/adaptor/in/RedisStreamConsumer.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/in/RedisStreamConsumer.java
@@ -16,6 +16,7 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 
 @Slf4j
 @Service
@@ -51,39 +52,53 @@ public class RedisStreamConsumer {
         try {
             String type = record.getValue().get("type");
             String payloadJson = record.getValue().get("payload");
+            JsonNode payloadNode = objectMapper.readTree(payloadJson);
 
             log.info("Processing record type={}, id={}", type, record.getId());
 
-            JsonNode payloadNode = objectMapper.readTree(payloadJson);
-
+            CompletableFuture<Void> future;
             switch (StreamMessageType.valueOf(type)) {
                 case REQUEST_CHAT_MESSAGE:
-                    processChatMessage(payloadNode);
+                    future = processChatMessage(payloadNode);
                     break;
                 case REQUEST_SUMMARY:
-                    processSummary(payloadNode);
+                    future = processSummary(payloadNode);
                     break;
                 case REQUEST_TOTAL_SUMMARY:
-                    processTotalSummary(payloadNode);
+                    future = processTotalSummary(payloadNode);
                     break;
                 case REQUEST_EXTRACT_METADATA:
-                    processMetadata(payloadNode);
+                    future = processMetadata(payloadNode);
                     break;
                 default:
                     log.warn("Unknown message type: {}", type);
+                    // 알 수 없는 타입은 바로 ACK 처리
+                    redisTemplate.opsForStream().acknowledge(streamKey, consumerGroup, record.getId());
+                    return;
             }
 
-            // 메시지 처리 완료 → ACK
-            redisTemplate.opsForStream().acknowledge(streamKey, consumerGroup, record.getId());
+            // 비동기 작업이 완료되었을 때의 처리
+            future.whenComplete((result, throwable) -> {
+                if (throwable != null) {
+                    // 비동기 작업 중 예외 발생 시
+                    log.error("Error processing record {} asynchronously", record.getId(), throwable);
+                    handleFailedMessage(record); // 실패 처리 로직 (DLQ 등)
+                } else {
+                    // 성공적으로 완료 시 ACK
+                    redisTemplate.opsForStream().acknowledge(streamKey, consumerGroup, record.getId());
+                    log.info("Successfully processed and acknowledged record id={}", record.getId());
+                }
+            });
 
         } catch (Exception e) {
+            // onMessage 메서드 자체에서 동기적으로 에러 발생 시
             log.error("Error processing record {}", record.getId(), e);
             handleFailedMessage(record);
         }
     }
 
-    private void processChatMessage(JsonNode payloadNode) {
-        processMessageUseCase.processStreamChatMessage(
+    private CompletableFuture<Void> processChatMessage(JsonNode payloadNode) {
+        return processMessageUseCase.processStreamChatMessage(
                 ProcessMessageUseCase.ProcessMessageCommand.builder()
                         .memberId(payloadNode.get("memberId").asLong())
                         .chatRoomId(payloadNode.get("chatRoomId").asLong())
@@ -93,8 +108,8 @@ public class RedisStreamConsumer {
         );
     }
 
-    private void processSummary(JsonNode payloadNode) {
-        processMessageUseCase.processSummary(
+    private CompletableFuture<Void> processSummary(JsonNode payloadNode) {
+        return processMessageUseCase.processSummary(
                 ProcessMessageUseCase.ProcessSummaryCommand.builder()
                         .chatRoomId(payloadNode.get("chatRoomId").asLong())
                         .promptLevel(payloadNode.get("promptLevel").asInt())
@@ -102,16 +117,16 @@ public class RedisStreamConsumer {
         );
     }
 
-    private void processTotalSummary(JsonNode payloadNode) {
-        processMessageUseCase.processTotalSummary(
+    private CompletableFuture<Void> processTotalSummary(JsonNode payloadNode) {
+        return processMessageUseCase.processTotalSummary(
                 ProcessMessageUseCase.ProcessTotalSummaryCommand.builder()
                         .chatRoomId(payloadNode.get("chatRoomId").asLong())
                         .build()
         );
     }
 
-    private void processMetadata(JsonNode payloadNode) {
-        processMessageUseCase.processAnswerMetadata(
+    private CompletableFuture<Void> processMetadata(JsonNode payloadNode) {
+        return processMessageUseCase.processAnswerMetadata(
                 ProcessMessageUseCase.ProcessAnswerCommand.builder()
                         .coupleId(payloadNode.get("coupleId").asLong())
                         .memberId(payloadNode.get("memberId").asLong())

--- a/src/main/java/makeus/cmc/malmo/adaptor/out/OpenAiApiClient.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/out/OpenAiApiClient.java
@@ -3,22 +3,27 @@ package makeus.cmc.malmo.adaptor.out;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import makeus.cmc.malmo.adaptor.out.exception.OpenAiRequestException;
 import makeus.cmc.malmo.application.port.out.chat.RequestChatApiPort;
-import okhttp3.*;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.Disposable;
+import reactor.core.publisher.Mono;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStreamReader;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Component
+@RequiredArgsConstructor
 public class OpenAiApiClient implements RequestChatApiPort {
 
     public static final String GPT_VERSION = "gpt-4o";
@@ -27,100 +32,78 @@ public class OpenAiApiClient implements RequestChatApiPort {
     @Value("${openai.api.key}")
     private String openAiApiKey;
 
-    private static final String OPENAI_CHAT_URL = "https://api.openai.com/v1/chat/completions";
-
-    private final OkHttpClient client = new OkHttpClient();
+    private final WebClient webClient;
+    private final ObjectMapper objectMapper;
 
     @Override
-    public void requestStreamResponse(List<Map<String, String>> messages,
-                                      Consumer<String> onData,
-                                      Consumer<String> onCompleteFullResponse,
-                                      Consumer<String> onError) {
-
+    public Mono<String> requestStreamResponse(List<Map<String, String>> messages, Consumer<String> onData) {
         Map<String, Object> body = createStreamBody(messages);
-        Request request = createStreamRequest(body, onError);
 
-        try (Response response = client.newCall(request).execute()) {
-            if (!response.isSuccessful()) {
-                log.error("OpenAI API request failed with code: {}", response.code());
-                onError.accept("에러가 발생했습니다: API 요청에 실패했습니다.");
-                return;
-            }
-
-            StringBuilder fullResponse = new StringBuilder();
-            try (BufferedReader reader = new BufferedReader(new InputStreamReader(response.body().byteStream()))) {
-                String line;
-                while ((line = reader.readLine()) != null) {
-                    if (line.startsWith("data: ")) {
-                        String data = line.substring(6).trim();
-                        if (data.equals("[DONE]")) break;
-
-                        String content = extractStreamContent(data);
-                        if (!content.isEmpty()) {
-                            fullResponse.append(content);
-                            onData.accept(content); // 실시간 콜백 호출
-                        }
+        // WebClient로 스트리밍 데이터를 Flux<String> 형태로 요청
+        return webClient.post()
+                .uri("/chat/completions")
+                .header("Authorization", "Bearer " + openAiApiKey)
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(body)
+                .retrieve()
+                .onStatus(HttpStatusCode::isError, response ->
+                        response.bodyToMono(String.class)
+                                .flatMap(errorBody -> {
+                                    log.error("OpenAI API error response: {}", errorBody);
+                                    return Mono.error(new RuntimeException("OpenAI API error: " + errorBody));
+                                })
+                )
+                .bodyToFlux(String.class)
+                .filter(line -> !line.isBlank()) // 비어있는 줄 필터링은 유지
+                .takeWhile(data -> !data.equals("[DONE]"))
+                .map(data -> {
+                    try {
+                        return extractStreamContent(data);
+                    } catch (JsonProcessingException e) {
+                        throw new RuntimeException("Failed to parse stream content", e);
                     }
-                }
-                onCompleteFullResponse.accept(fullResponse.toString());
-            }
-        } catch (IOException e) {
-            log.error("Failed to connect to OpenAI API", e);
-            onError.accept("에러가 발생했습니다: 네트워크 연결에 실패했습니다.");
-        } catch (Exception e) {
-            log.error("Error processing OpenAI API response", e);
-            onError.accept("에러가 발생했습니다: 응답 처리 중 문제가 발생했습니다.");
-        }
+                })
+                .filter(content -> !content.isEmpty())
+                .doOnNext(onData)
+                .collect(Collectors.joining(""))
+                .doOnError(throwable -> log.error("Error during OpenAI stream processing", throwable));
     }
 
     @Override
-    public String requestResponse(List<Map<String, String>> messages) {
+    public CompletableFuture<String> requestResponse(List<Map<String, String>> messages) {
         Map<String, Object> body = createBody(messages);
-        Request request = createRequest(body);
-
-        try (Response response = client.newCall(request).execute()) {
-            if (!response.isSuccessful()) {
-                log.error("OpenAI API request failed with code: {}", response.code());
-                return "";
-            }
-
-            String data = response.body().string();
-
-            return extractContent(data);
-        } catch (IOException e) {
-            log.error("Failed to connect to OpenAI API", e);
-        } catch (Exception e) {
-            log.error("Error processing OpenAI API response", e);
-        }
-        return "";
+        return sendRequest(body)
+                .thenApply(this::extractContent); // 응답이 오면 extractContent 실행
     }
 
     @Override
-    public String requestJsonResponse(List<Map<String, String>> messages) {
-        // OpenAI API에 요청할 때 응답 형식을 JSON으로 지정
+    public CompletableFuture<String> requestJsonResponse(List<Map<String, String>> messages) {
         Map<String, Object> body = createBodyForJsonResponse(messages);
-        Request request = createRequest(body);
-        log.info("Requesting OpenAI API with body: {}", body);
+        return sendRequest(body)
+                .thenApply(this::extractContent); // 응답이 오면 extractContent 실행
+    }
 
-        try (Response response = client.newCall(request).execute()) {
-            log.info("OpenAI API response code: {}", response.code());
+    private CompletableFuture<String> sendRequest(Map<String, Object> body) {
+        return webClient.post()
+                .uri("/chat/completions")
+                .header("Authorization", "Bearer " + openAiApiKey)
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(body)
+                .retrieve()
+                .bodyToMono(String.class) // 응답 바디를 Mono<String>으로 받음
+                .toFuture(); // Mono를 CompletableFuture로 변환
+    }
 
-            if (!response.isSuccessful()) {
-                log.error("OpenAI API request failed with code: {}", response.code());
-                log.info("Failed Body: {}", response.body().string());
-                throw new OpenAiRequestException("OpenAI API request failed with code: " + response.code());
-            }
-
-            String data = response.body().string();
-            log.info("OpenAI API response data: {}", extractContent(data));
-            return extractContent(data);
-        } catch (IOException e) {
-            throw new OpenAiRequestException("Failed to connect to OpenAI API");
-        } catch (Exception e) {
-            e.printStackTrace();
-            throw new OpenAiRequestException("Error processing OpenAI API response");
+    private String extractContent(String data) {
+        try {
+            JsonNode node = objectMapper.readTree(data);
+            return node.path("choices").get(0).path("message").path("content").asText();
+        } catch (JsonProcessingException e) {
+            log.error("Error processing OpenAI API response", e);
+            throw new RuntimeException(e); // 예외를 던져 CompletableFuture가 exceptionally로 처리하게 함
         }
     }
+
 
     private String extractStreamContent(String data) throws JsonProcessingException {
         JsonNode node = new ObjectMapper().readTree(data);
@@ -129,50 +112,6 @@ public class OpenAiApiClient implements RequestChatApiPort {
                 .path("delta")
                 .path("content")
                 .asText();
-    }
-
-    private String extractContent(String data) throws JsonProcessingException {
-        JsonNode node = new ObjectMapper().readTree(data);
-        return node
-                .path("choices").get(0)
-                .path("message")
-                .path("content")
-                .asText();
-    }
-
-    private Request createStreamRequest(Map<String, Object> body, Consumer<String> onError) {
-        Request request = null;
-        try {
-            request = new Request.Builder()
-                    .url(OPENAI_CHAT_URL)
-                    .post(RequestBody.create(
-                            new ObjectMapper().writeValueAsString(body),
-                            MediaType.get("application/json")))
-                    .header("Authorization", "Bearer " + openAiApiKey)
-                    .header("Content-Type", "application/json")
-                    .build();
-        } catch (JsonProcessingException e) {
-            log.error("Error processing OpenAI API response", e);
-            onError.accept("에러가 발생했습니다: 요청 생성 중 문제가 발생했습니다.");
-        }
-        return request;
-    }
-
-    private Request createRequest(Map<String, Object> body) {
-        Request request = null;
-        try {
-            request = new Request.Builder()
-                    .url(OPENAI_CHAT_URL)
-                    .post(RequestBody.create(
-                            new ObjectMapper().writeValueAsString(body),
-                            MediaType.get("application/json")))
-                    .header("Authorization", "Bearer " + openAiApiKey)
-                    .header("Content-Type", "application/json")
-                    .build();
-        } catch (JsonProcessingException e) {
-            log.error("Error processing OpenAI API response", e);
-        }
-        return request;
     }
 
     private Map<String, Object> createStreamBody(List<Map<String, String>> messages) {

--- a/src/main/java/makeus/cmc/malmo/application/port/in/chat/ProcessMessageUseCase.java
+++ b/src/main/java/makeus/cmc/malmo/application/port/in/chat/ProcessMessageUseCase.java
@@ -3,12 +3,14 @@ package makeus.cmc.malmo.application.port.in.chat;
 import lombok.Builder;
 import lombok.Data;
 
+import java.util.concurrent.CompletableFuture;
+
 public interface ProcessMessageUseCase {
 
-    void processStreamChatMessage(ProcessMessageCommand command);
-    void processSummary(ProcessSummaryCommand command);
-    void processTotalSummary(ProcessTotalSummaryCommand command);
-    void processAnswerMetadata(ProcessAnswerCommand command);
+    CompletableFuture<Void> processStreamChatMessage(ProcessMessageCommand command);
+    CompletableFuture<Void> processSummary(ProcessSummaryCommand command);
+    CompletableFuture<Void> processTotalSummary(ProcessTotalSummaryCommand command);
+    CompletableFuture<Void> processAnswerMetadata(ProcessAnswerCommand command);
 
     @Data
     @Builder

--- a/src/main/java/makeus/cmc/malmo/application/port/out/chat/RequestChatApiPort.java
+++ b/src/main/java/makeus/cmc/malmo/application/port/out/chat/RequestChatApiPort.java
@@ -1,17 +1,16 @@
 package makeus.cmc.malmo.application.port.out.chat;
 
+import reactor.core.publisher.Mono;
+
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 
 public interface RequestChatApiPort {
-    void requestStreamResponse(
-            List<Map<String, String>> messages,
-            Consumer<String> onData,
-            Consumer<String> onCompleteFullResponse,
-            Consumer<String> onError);
+    Mono<String> requestStreamResponse(List<Map<String, String>> messages, Consumer<String> onData);
 
-    String requestResponse(List<Map<String, String>> messages);
+    CompletableFuture<String> requestResponse(List<Map<String, String>> messages);
 
-    String requestJsonResponse(List<Map<String, String>> messages);
+    CompletableFuture<String> requestJsonResponse(List<Map<String, String>> messages);
 }

--- a/src/main/java/makeus/cmc/malmo/application/service/chat/ChatMessageService.java
+++ b/src/main/java/makeus/cmc/malmo/application/service/chat/ChatMessageService.java
@@ -1,6 +1,7 @@
 package makeus.cmc.malmo.application.service.chat;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import makeus.cmc.malmo.application.helper.chat_room.ChatRoomCommandHelper;
 import makeus.cmc.malmo.application.helper.chat_room.ChatRoomQueryHelper;
 import makeus.cmc.malmo.application.helper.chat_room.PromptQueryHelper;
@@ -28,8 +29,10 @@ import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ChatMessageService implements ProcessMessageUseCase {
@@ -51,7 +54,7 @@ public class ChatMessageService implements ProcessMessageUseCase {
     private final MemberMemoryCommandHelper memberMemoryCommandHelper;
 
     @Override
-    public void processStreamChatMessage(ProcessMessageCommand command) {
+    public CompletableFuture<Void> processStreamChatMessage(ProcessMessageCommand command) {
         MemberId memberId = MemberId.of(command.getMemberId());
         Member member = memberQueryHelper.getMemberByIdOrThrow(memberId);
         ChatRoom chatRoom = chatRoomQueryHelper.getChatRoomByIdOrThrow(ChatRoomId.of(command.getChatRoomId()));
@@ -64,33 +67,31 @@ public class ChatMessageService implements ProcessMessageUseCase {
 
         AtomicBoolean isOkDetected = new AtomicBoolean(false);
 
-        chatProcessor.streamChat(messages, systemPrompt, prompt,
+        return chatProcessor.streamChat(messages, systemPrompt, prompt,
                 chunk -> {
+                    // 실시간 SSE 전송 로직 (onChunk)
                     if (chunk.contains("OK")) {
-                        // OK 응답이 감지되면 isOkDetected를 true로 설정
                         isOkDetected.set(true);
                     } else {
-                        // OK가 감지되지 않은 경우 SSE 응답 스트리밍
                         chatSseSender.sendResponseChunk(memberId, chunk);
                     }
                 },
                 fullAnswer -> {
+                    // 스트림 완료 후 DB 저장 및 후처리 로직 (onComplete)
                     if (!isOkDetected.get()) {
-                        // OK가 감지되지 않은 경우 전체 응답을 저장
                         saveAiMessage(memberId, ChatRoomId.of(chatRoom.getId()), prompt.getLevel(), fullAnswer);
                     } else {
-                        // OK가 감지된 경우 OK를 제거하고 저장 후 현재 레벨 완료 처리
                         fullAnswer = fullAnswer.replace("OK", "").trim();
                         saveAiMessage(memberId, ChatRoomId.of(chatRoom.getId()), prompt.getLevel(), fullAnswer);
                         handleLevelFinished(memberId, ChatRoomId.of(chatRoom.getId()), prompt, isMemberCouple);
                     }
                 },
                 errorMessage -> chatSseSender.sendError(memberId, errorMessage)
-        );
+        ).toFuture();
     }
 
     @Override
-    public void processSummary(ProcessSummaryCommand command) {
+    public CompletableFuture<Void> processSummary(ProcessSummaryCommand command) {
         ChatRoom chatRoom = chatRoomQueryHelper.getChatRoomByIdOrThrow(ChatRoomId.of(command.getChatRoomId()));
         Prompt systemPrompt = promptQueryHelper.getSystemPrompt();
         Prompt prompt = promptQueryHelper.getPromptByLevel(chatRoom.getLevel());
@@ -98,16 +99,17 @@ public class ChatMessageService implements ProcessMessageUseCase {
 
         // 현재 단계 채팅에 대한 전체 요약 요청
         List<Map<String, String>> summaryMessages = chatPromptBuilder.createForSummaryAsync(chatRoom);
-        String summary = chatProcessor.requestSummaryAsync(summaryMessages, systemPrompt, prompt, summaryPrompt);
-
-        ChatMessageSummary chatMessageSummary = ChatMessageSummary.createChatMessageSummary(
-                ChatRoomId.of(chatRoom.getId()), summary, prompt.getLevel());
-
-        saveChatMessageSummaryPort.saveChatMessageSummary(chatMessageSummary);
+        return chatProcessor.requestSummaryAsync(summaryMessages, systemPrompt, prompt, summaryPrompt)
+                .thenAcceptAsync(summary -> { // 비동기 작업이 끝나면 이 블록이 실행됨
+                    ChatMessageSummary chatMessageSummary = ChatMessageSummary.createChatMessageSummary(
+                            ChatRoomId.of(chatRoom.getId()), summary, prompt.getLevel());
+                    saveChatMessageSummaryPort.saveChatMessageSummary(chatMessageSummary);
+                    log.info("Successfully processed and saved summary for chatRoomId: {}", command.getChatRoomId());
+                }); // 별도의 스레드 풀에서 실행되도록 thenAcceptAsync 사용
     }
 
     @Override
-    public void processTotalSummary(ProcessTotalSummaryCommand command) {
+    public CompletableFuture<Void> processTotalSummary(ProcessTotalSummaryCommand command) {
         ChatRoom chatRoom = chatRoomQueryHelper.getChatRoomByIdOrThrow(ChatRoomId.of(command.getChatRoomId()));
 
         Prompt systemPrompt = promptQueryHelper.getSystemPrompt();
@@ -115,19 +117,21 @@ public class ChatMessageService implements ProcessMessageUseCase {
 
         List<Map<String, String>> messages = chatPromptBuilder.createForTotalSummary(chatRoom);
 
-        ChatProcessor.CounselingSummary summary = chatProcessor
-                .requestTotalSummary(messages, systemPrompt, totalSummaryPrompt);
-
-        chatRoom.updateChatRoomSummary(
-                summary.getTotalSummary(),
-                summary.getSituationKeyword(),
-                summary.getSolutionKeyword()
-        );
-        chatRoomCommandHelper.saveChatRoom(chatRoom);
+        return chatProcessor.requestTotalSummary(messages, systemPrompt, totalSummaryPrompt)
+                .thenAcceptAsync(summary -> { // CounselingSummary 객체를 받음
+                    chatRoom.updateChatRoomSummary(
+                            summary.getTotalSummary(),
+                            summary.getSituationKeyword(),
+                            summary.getSolutionKeyword()
+                    );
+                    chatRoomCommandHelper.saveChatRoom(chatRoom);
+                    log.info("Successfully processed and saved total summary for chatRoomId: {}", command.getChatRoomId());
+                });
     }
 
     @Override
-    public void processAnswerMetadata(ProcessAnswerCommand command) {
+    public CompletableFuture<Void> processAnswerMetadata(ProcessAnswerCommand command) {
+        // 1. 비동기 작업에 필요한 데이터는 미리 동기적으로 조회합니다.
         MemberAnswer memberAnswer = coupleQuestionQueryHelper.getMemberAnswerOrThrow(
                 CoupleQuestionId.of(command.getCoupleQuestionId()),
                 MemberId.of(command.getMemberId()));
@@ -137,19 +141,22 @@ public class ChatMessageService implements ProcessMessageUseCase {
 
         Prompt metadataPrompt = promptQueryHelper.getMemberAnswerMetadata();
 
-        String metadata = chatProcessor.requestMetaData(
-                coupleQuestion.getQuestion().getContent(),
-                memberAnswer.getAnswer(),
-                metadataPrompt
-        );
+        // 2. 비동기 API 호출로 CompletableFuture 체인을 시작하고, 그 결과를 즉시 반환합니다.
+        return chatProcessor.requestMetaData(
+                        coupleQuestion.getQuestion().getContent(),
+                        memberAnswer.getAnswer(),
+                        metadataPrompt
+                )
+                // 3. API 호출이 성공적으로 완료되면(then), 그 결과(metadata)를 받아서(Accept) 다음 작업을 비동기(Async)로 실행합니다.
+                .thenAcceptAsync(metadata -> {
+                    // 멤버 메모리 생성 및 저장
+                    MemberMemory memberMemory = MemberMemory.createMemberMemory(
+                            CoupleId.of(command.getCoupleId()),
+                            MemberId.of(command.getMemberId()),
+                            metadata);
 
-        // 멤버 메모리 생성 및 저장
-        MemberMemory memberMemory = MemberMemory.createMemberMemory(
-                CoupleId.of(command.getCoupleId()),
-                MemberId.of(command.getMemberId()),
-                metadata);
-
-        memberMemoryCommandHelper.saveMemberMemory(memberMemory);
+                    memberMemoryCommandHelper.saveMemberMemory(memberMemory);
+                });
     }
 
     /*

--- a/src/main/java/makeus/cmc/malmo/application/service/chat/CurrentChatRoomService.java
+++ b/src/main/java/makeus/cmc/malmo/application/service/chat/CurrentChatRoomService.java
@@ -124,6 +124,7 @@ public class CurrentChatRoomService
     public CompleteChatRoomResponse completeChatRoom(CompleteChatRoomCommand command) {
         ChatRoom chatRoom = chatRoomQueryHelper.getCurrentChatRoomByMemberIdOrThrow(MemberId.of(command.getUserId()));
         chatRoom.complete();
+        chatRoomCommandHelper.saveChatRoom(chatRoom);
 
         // 완료된 채팅방의 요약을 요청
         log.info("채팅방 요약 요청 스트림 추가: chatRoomId={}", chatRoom.getId());

--- a/src/main/java/makeus/cmc/malmo/config/MainConfiguration.java
+++ b/src/main/java/makeus/cmc/malmo/config/MainConfiguration.java
@@ -5,6 +5,10 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import static makeus.cmc.malmo.util.GlobalConstants.OPENAI_CHAT_URL;
+
 
 @Configuration
 public class MainConfiguration {
@@ -17,4 +21,10 @@ public class MainConfiguration {
         return objectMapper;
     }
 
+    @Bean
+    public WebClient webClient() {
+        return WebClient.builder()
+                .baseUrl(OPENAI_CHAT_URL)
+                .build();
+    }
 }

--- a/src/main/java/makeus/cmc/malmo/util/GlobalConstants.java
+++ b/src/main/java/makeus/cmc/malmo/util/GlobalConstants.java
@@ -25,4 +25,7 @@ public class GlobalConstants {
 
     public static final String COMPLETED_ROOM_CREATING_SUMMARY_LINE = "채팅방이 종료되었습니다. 요약 생성 중...";
 
+    public static final String OPENAI_CHAT_URL = "https://api.openai.com/v1";
+
+
 }


### PR DESCRIPTION
## 📝 작업 내용

> 외부 API를 OkHttp execute()로 요청하여 스레드 점유 문제가 있었던 기존 로직을 CompletableFuture를 이용하여 비동기 처리
> TPS 10배 성능 달성
