### PR TITLE
채팅 데이터 암호화

### DIFF
--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -2,12 +2,13 @@ name: Deploy to AWS EC2
 
 on:
   push:
-    branches: [ develop ]
+    branches: [ release ]
   pull_request:
-    branches: [ develop ]
+    branches: [ release ]
 
 jobs:
   build-and-deploy:
+    if: contains(github.event.head_commit.message, 'release-test-green') || contains(github.event.head_commit.message, 'release-test-blue')
     runs-on: ubuntu-latest
 
     services:
@@ -63,15 +64,27 @@ jobs:
       - name: Run tests with Gradle
         run: ./gradlew test --no-daemon
 
-      # 5. 빌드 (develop 브랜치 push일 경우에만 실행)
-      # Pull Request가 아닌 develop 브랜치 푸시일 때만 아래 스텝들이 실행됩니다.
+      # 5. 빌드 (release 브랜치 push일 경우에만 실행)
       - name: Build with Gradle
-        if: github.ref == 'refs/heads/develop' && github.event_name == 'push'
+        if: github.ref == 'refs/heads/release' && github.event_name == 'push'
         run: ./gradlew bootJar --no-daemon
+
+      # 6. 커밋 메시지에 따라 포트 번호 설정
+      - name: Set Port based on Commit Message
+        id: set_port
+        if: github.ref == 'refs/heads/release' && github.event_name == 'push'
+        run: |
+          if [[ "${{ github.event.head_commit.message }}" == *"release-green"* ]]; then
+            echo "port=8080" >> $GITHUB_OUTPUT
+            echo "Port set to 8080 for green deployment."
+          elif [[ "${{ github.event.head_commit.message }}" == *"release-blue"* ]]; then
+            echo "port=8081" >> $GITHUB_OUTPUT
+            echo "Port set to 8081 for blue deployment."
+          fi
 
       # 6. Docker Hub 로그인 (배포 시에만)
       - name: Login to Docker Hub
-        if: github.ref == 'refs/heads/develop' && github.event_name == 'push'
+        if: github.ref == 'refs/heads/release' && github.event_name == 'push'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -79,7 +92,7 @@ jobs:
 
       # 7. Docker 이미지 빌드 및 푸시
       - name: Build and push Docker image
-        if: github.ref == 'refs/heads/develop' && github.event_name == 'push'
+        if: github.ref == 'refs/heads/release' && github.event_name == 'push'
         env:
           IMAGE_NAME: ${{ secrets.DOCKERHUB_USERNAME }}/malmo-test
         run: |
@@ -89,7 +102,7 @@ jobs:
 
       # 8. EC2에 배포
       - name: Deploy to EC2
-        if: github.ref == 'refs/heads/develop' && github.event_name == 'push'
+        if: github.ref == 'refs/heads/release' && github.event_name == 'push'
         uses: appleboy/ssh-action@v1.0.3
         with:
           host: ${{ secrets.TEST_EC2_HOST }}
@@ -117,7 +130,7 @@ jobs:
                 image: ${{ secrets.DOCKERHUB_USERNAME }}/malmo-test:latest
                 container_name: malmo-test
                 ports:
-                  - "8081:8080"
+                  - "${{ steps.set_port.outputs.port }}:8080"
                 environment:
                   - TZ=Asia/Seoul
                   - SPRING_PROFILES_ACTIVE=prod
@@ -141,6 +154,7 @@ jobs:
                   - SECURITY_CLIENT_URL_DEVELOPMENT=${{ secrets.SECURITY_CLIENT_URL_DEVELOPMENT }}
                   - SECURITY_SERVER_URL_PRODUCTION=${{ secrets.SECURITY_SERVER_URL_PRODUCTION }}
                   - SECURITY_SERVER_URL_DEVELOPMENT=${{ secrets.SECURITY_SERVER_URL_DEVELOPMENT }}
+                  - AES_ENCRYPTION_KEY=${{ secrets.AES_ENCRYPTION_KEY }}
                 restart: unless-stopped
                 networks:
                   - malmo-net

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -166,6 +166,8 @@ jobs:
                   REDIS_ADDR: "redis:6379"
                 depends_on:
                   - redis
+                networks:
+                  - malmo-net
 
             networks:
               malmo-net:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -107,6 +107,8 @@ jobs:
             # 기존 컨테이너 중지 및 삭제
             docker stop malmo-app || true
             docker rm malmo-app || true
+            docker stop redis-exporter || true
+            docker rm redis-exporter || true
 
             # docker-compose.yml 파일 생성
             cat << 'EOF' > docker-compose.yml

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -157,6 +157,15 @@ jobs:
                 networks:
                   - malmo-net
                 restart: always
+            
+              redis-exporter:
+                image: oliver006/redis_exporter:latest
+                ports:
+                  - "9121:9121"
+                environment:
+                  REDIS_ADDR: "redis:6379"
+                depends_on:
+                  - redis
 
             networks:
               malmo-net:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,12 +2,13 @@ name: Deploy to AWS EC2
 
 on:
   push:
-    branches: [ main ]
+    branches: [ release ]
   pull_request:
-    branches: [ main ]
+    branches: [ release ]
 
 jobs:
   build-and-deploy:
+    if: contains(github.event.head_commit.message, 'release-green') || contains(github.event.head_commit.message, 'release-blue')
     runs-on: ubuntu-latest
 
     services:
@@ -63,15 +64,27 @@ jobs:
       - name: Run tests with Gradle
         run: ./gradlew test --no-daemon
 
-      # 5. 빌드 (main 브랜치 push일 경우에만 실행)
-      # Pull Request가 아닌 main 브랜치 푸시일 때만 아래 스텝들이 실행됩니다.
+      # 5. 빌드 (release 브랜치 push일 경우에만 실행)
       - name: Build with Gradle
-        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        if: github.ref == 'refs/heads/release' && github.event_name == 'push'
         run: ./gradlew bootJar --no-daemon
+
+      # 6. 커밋 메시지에 따라 포트 번호 설정
+      - name: Set Port based on Commit Message
+        id: set_port
+        if: github.ref == 'refs/heads/release' && github.event_name == 'push'
+        run: |
+          if [[ "${{ github.event.head_commit.message }}" == *"release-green"* ]]; then
+            echo "port=8080" >> $GITHUB_OUTPUT
+            echo "Port set to 8080 for green deployment."
+          elif [[ "${{ github.event.head_commit.message }}" == *"release-blue"* ]]; then
+            echo "port=8081" >> $GITHUB_OUTPUT
+            echo "Port set to 8081 for blue deployment."
+          fi
 
       # 6. Docker Hub 로그인 (배포 시에만)
       - name: Login to Docker Hub
-        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        if: github.ref == 'refs/heads/release' && github.event_name == 'push'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -79,9 +92,9 @@ jobs:
 
       # 7. Docker 이미지 빌드 및 푸시
       - name: Build and push Docker image
-        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        if: github.ref == 'refs/heads/release' && github.event_name == 'push'
         env:
-          IMAGE_NAME: ${{ secrets.DOCKERHUB_USERNAME }}/malmo-app
+          IMAGE_NAME: ${{ secrets.DOCKERHUB_USERNAME }}/malmo-test
         run: |
           docker build --platform linux/amd64 -t $IMAGE_NAME:${{ github.sha }} -t $IMAGE_NAME:latest .
           docker push $IMAGE_NAME:${{ github.sha }}
@@ -89,12 +102,12 @@ jobs:
 
       # 8. EC2에 배포
       - name: Deploy to EC2
-        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        if: github.ref == 'refs/heads/release' && github.event_name == 'push'
         uses: appleboy/ssh-action@v1.0.3
         with:
-          host: ${{ secrets.EC2_HOST }}
+          host: ${{ secrets.TEST_EC2_HOST }}
           username: ${{ secrets.EC2_USERNAME }}
-          key: ${{ secrets.EC2_PRIVATE_KEY }}
+          key: ${{ secrets.TEST_EC2_PRIVATE_KEY }}
           script: |
             echo ${{ secrets.DOCKERHUB_TOKEN }} | docker login --username ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
             
@@ -105,32 +118,26 @@ jobs:
             fi
 
             # 기존 컨테이너 중지 및 삭제
-            docker stop malmo-app || true
-            docker rm malmo-app || true
-            docker stop redis-exporter || true
-            docker rm redis-exporter || true
+            docker stop malmo-test || true
+            docker rm malmo-test || true
 
             # docker-compose.yml 파일 생성
-            cat << 'EOF' > docker-compose.yml
+            cat << 'EOF' > docker-compose.test.yml
             version: '3.8'
 
             services:
-              malmo-app:
-                image: ${{ secrets.DOCKERHUB_USERNAME }}/malmo-app:latest
-                container_name: malmo-app
-                depends_on:
-                  - redis
+              malmo-test:
+                image: ${{ secrets.DOCKERHUB_USERNAME }}/malmo-test:latest
+                container_name: malmo-test
                 ports:
-                  - "8080:8080"
-                networks:
-                  - malmo-net
+                  - "${{ steps.set_port.outputs.port }}:8080"
                 environment:
                   - TZ=Asia/Seoul
                   - SPRING_PROFILES_ACTIVE=prod
                   - SPRING_DATASOURCE_URL=${{ secrets.DB_URL }}
                   - SPRING_DATASOURCE_USERNAME=${{ secrets.DB_USERNAME }}
                   - SPRING_DATASOURCE_PASSWORD=${{ secrets.DB_PASSWORD }}
-                  - SPRING_DATA_REDIS_HOST=redis
+                  - SPRING_DATA_REDIS_HOST=malmo-redis
                   - REDIS_STREAM_KEY=${{ secrets.REDIS_STREAM_KEY }}
                   - REDIS_CONSUMER_GROUP=${{ secrets.REDIS_CONSUMER_GROUP }}
                   - JWT_SECRET=${{ secrets.JWT_SECRET }}
@@ -142,49 +149,27 @@ jobs:
                   - APPLE_CLIENT_ID=${{ secrets.APPLE_CLIENT_ID }}
                   - KAKAO_ADMIN_KEY=${{ secrets.KAKAO_ADMIN_KEY }}
                   - OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }}
-                  - SWAGGER_SERVER_PRODUCTION_URL=${{ secrets.SWAGGER_SERVER_PRODUCTION_URL }}
+                  - SWAGGER_SERVER_PRODUCTION_URL=${{ secrets.TEST_SWAGGER_SERVER_PRODUCTION_URL }}
                   - SECURITY_CLIENT_URL_PRODUCTION=${{ secrets.SECURITY_CLIENT_URL_PRODUCTION }}
                   - SECURITY_CLIENT_URL_DEVELOPMENT=${{ secrets.SECURITY_CLIENT_URL_DEVELOPMENT }}
                   - SECURITY_SERVER_URL_PRODUCTION=${{ secrets.SECURITY_SERVER_URL_PRODUCTION }}
                   - SECURITY_SERVER_URL_DEVELOPMENT=${{ secrets.SECURITY_SERVER_URL_DEVELOPMENT }}
+                  - AES_ENCRYPTION_KEY=${{ secrets.AES_ENCRYPTION_KEY }}
                 restart: unless-stopped
-
-              redis:
-                image: "redis:7-alpine"
-                container_name: malmo-redis
-                ports:
-                  - "6379:6379"
-                volumes:
-                  - redis-data:/data
-                networks:
-                  - malmo-net
-                restart: always
-            
-              redis-exporter:
-                image: oliver006/redis_exporter:latest
-                ports:
-                  - "9121:9121"
-                environment:
-                  REDIS_ADDR: "redis:6379"
-                depends_on:
-                  - redis
                 networks:
                   - malmo-net
 
             networks:
               malmo-net:
                 external: true
-
-            volumes:
-              redis-data:
             EOF
 
             # Docker Hub 로그인
             echo ${{ secrets.DOCKERHUB_TOKEN }} | docker login --username ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
 
             # docker-compose로 애플리케이션 실행
-            docker-compose pull
-            docker-compose up -d
+            docker-compose -f docker-compose.test.yml pull
+            docker-compose -f docker-compose.test.yml up -d
 
             # 불필요한 Docker 이미지 정리
             docker image prune -f

--- a/README.md
+++ b/README.md
@@ -1,3 +1,80 @@
-# malmo-server
+# 💌 말모 Malmo - AI 연애 상담, 마음 질문
+
+## 🧐 프로젝트 소개
+
+> **"연인은 왜 저런 반응을 할까?", "이럴 땐 어떻게 대응해야 하지?"**
+
+말모(Malmo)는 연인 사이의 갈등과 고민에서 출발한 **애착 유형 기반 AI 연애 갈등 상담 앱**입니다.
+
+MZ세대는 연인과의 갈등 원인으로 '의사소통 방식'과 '성향 차이'를 가장 많이 꼽았으며, 자신과 연인을 이해하려는 니즈가 높습니다.  
+말모(Malmo)는 사용자와 연인의 애착 유형 데이터를 기반으로 갈등 상황을 분석하고, 관계 개선을 위한 맞춤형 조언을 제공하는 서비스입니다.
 
 ---
+
+## ✨ 주요 기능
+
+### 1. 애착 유형 진단
+
+- ECR 검사 문항 기반 애착 유형 진단
+- 커플 연동으로 서로의 결과 공유 및 AI 상담에 활용
+
+### 2. AI 갈등 상담
+
+- 채팅으로 갈등 상황 입력 → AI가 애착 유형 기반 상담 제공
+- 상담 종료 후, 요약 리포트 제공
+
+### 3. 커플 질문
+
+- 매일 새로운 커플 질문 제공
+- 누적 답변은 AI 상담 분석에 활용 + 커플 레벨 상승 요소 제공
+
+---
+
+## 🖼️ 스크린샷
+
+<div align="center">
+   <img width="800" alt="스크린샷" src="https://github.com/user-attachments/assets/e0960f87-1ba4-453c-ab97-2dd3254727de" />
+   <img width="800" alt="Frame 1948756838" src="https://github.com/user-attachments/assets/4d61401f-020c-4da2-8260-465331d66fa4" />
+</div>
+
+---
+
+## 🛠️ 기술 스택
+
+| Category          | Tools & Technologies |
+|-------------------|-----------------------|
+| **Frameworks**    | ![Spring](https://img.shields.io/badge/Spring-6DB33F?style=flat&logo=spring&logoColor=white) ![Spring Security](https://img.shields.io/badge/Spring%20Security-6DB33F?style=flat&logo=springsecurity&logoColor=white) |
+| **Language**      | ![Java](https://img.shields.io/badge/Java%2017-007396?style=flat&logo=openjdk&logoColor=white) |
+| **Persistence**   | ![Spring Data JPA](https://img.shields.io/badge/Spring%20Data%20JPA-007396?style=flat&logo=hibernate&logoColor=white) ![QueryDSL](https://img.shields.io/badge/QueryDSL-59666C?style=flat) |
+| **Database**      | ![MySQL](https://img.shields.io/badge/MySQL-4479A1?style=flat&logo=mysql&logoColor=white) |
+| **Cloud (AWS)**   | ![EC2](https://img.shields.io/badge/EC2-FF9900?style=flat&logo=amazon-ec2&logoColor=white) ![S3](https://img.shields.io/badge/S3-569A31?style=flat&logo=amazon-s3&logoColor=white) ![RDS](https://img.shields.io/badge/RDS-527FFF?style=flat&logo=amazon-rds&logoColor=white) |
+| **Messaging**     | ![redis](https://img.shields.io/badge/Redis-DC382D?style=flat&logo=redis&logoColor=white) |
+| **Container & DevOps** | ![Docker](https://img.shields.io/badge/Docker-2496ED?style=flat&logo=docker&logoColor=white) |
+| **Monitoring**    | ![Prometheus](https://img.shields.io/badge/Prometheus-E6522C?style=flat&logo=prometheus&logoColor=white) ![Grafana](https://img.shields.io/badge/Grafana-F46800?style=flat&logo=grafana&logoColor=white) |
+| **Documentation** | ![Swagger](https://img.shields.io/badge/Swagger-85EA2D?style=flat&logo=swagger&logoColor=black) |
+| **Testing**       | ![JUnit5](https://img.shields.io/badge/JUnit%205-25A162?style=flat&logo=junit5&logoColor=white) ![Mockito](https://img.shields.io/badge/Mockito-007396?style=flat&logo=java&logoColor=white) |
+| **CI/CD**         | ![GitHub Actions](https://img.shields.io/badge/GitHub%20Actions-2088FF?style=flat&logo=githubactions&logoColor=white) |
+
+
+
+---
+
+## 🚎 Architecture
+
+<div align="center">
+  <img width="600" height="440" alt="malmo_arch" src="https://github.com/user-attachments/assets/1d494e5e-6d46-4963-8a64-92617ae574d0" />
+</div>
+
+---
+
+## 📈 DataBase Schema
+
+<img width="3840" height="2566" alt="malmo-erd" src="https://github.com/user-attachments/assets/c848c59a-910d-48e1-9078-7ed61c2bc211" />
+
+
+---
+
+## 📄 라이선스
+
+이 프로젝트는 [MIT License](./LICENSE)를 따릅니다.  
+© 2025 Malmo. All rights reserved.

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ MZ세대는 연인과의 갈등 원인으로 '의사소통 방식'과 '성향 �
 ## 🚎 Architecture
 
 <div align="center">
-  <img width="600" height="440" alt="malmo_arch" src="https://github.com/user-attachments/assets/1d494e5e-6d46-4963-8a64-92617ae574d0" />
+   <img width="700" height="500" alt="malmo_arch drawio" src="https://github.com/user-attachments/assets/1b9b735a-6441-4c18-83b5-fff7647f6345" />
 </div>
 
 ---

--- a/src/main/java/makeus/cmc/malmo/MalmoApplication.java
+++ b/src/main/java/makeus/cmc/malmo/MalmoApplication.java
@@ -3,7 +3,9 @@ package makeus.cmc.malmo;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @EnableJpaAuditing
 @SpringBootApplication
 public class MalmoApplication {

--- a/src/main/java/makeus/cmc/malmo/adaptor/in/RedisStreamConsumer.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/in/RedisStreamConsumer.java
@@ -174,6 +174,9 @@ public class RedisStreamConsumer {
 
                 redisTemplate.opsForStream().add(dlqRecord);
             }
+
+            // 기존 메시지는 ACK 처리해서 PEL에서 제거
+            redisTemplate.opsForStream().acknowledge(streamKey, consumerGroup, record.getId());
         } catch (Exception e) {
             log.error("Error handling failed message: {}", record.getId(), e);
         }

--- a/src/main/java/makeus/cmc/malmo/adaptor/in/web/controller/NotificationController.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/in/web/controller/NotificationController.java
@@ -11,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import makeus.cmc.malmo.adaptor.in.web.docs.ApiCommonResponses;
 import makeus.cmc.malmo.adaptor.in.web.docs.SwaggerResponses;
+import makeus.cmc.malmo.adaptor.in.web.dto.BaseListResponse;
 import makeus.cmc.malmo.adaptor.in.web.dto.BaseResponse;
 import makeus.cmc.malmo.application.port.in.notification.GetPendingNotificationUseCase;
 import makeus.cmc.malmo.application.port.in.notification.ProcessReadNotificationsUseCase;
@@ -42,13 +43,15 @@ public class NotificationController {
     )
     @ApiCommonResponses.RequireAuth
     @GetMapping("/pending")
-    public BaseResponse<GetPendingNotificationUseCase.GetPendingNotificationResponse> getMemberPendingNotification(
+    public BaseResponse<BaseListResponse<GetPendingNotificationUseCase.PendingNotificationData>> getMemberPendingNotification(
             @AuthenticationPrincipal User user
     ) {
         GetPendingNotificationUseCase.GetPendingNotificationCommand command = GetPendingNotificationUseCase.GetPendingNotificationCommand.builder()
                 .userId(Long.valueOf(user.getUsername()))
                 .build();
-        return BaseResponse.success(getPendingNotificationUseCase.getPendingNotifications(command));
+
+        List<GetPendingNotificationUseCase.PendingNotificationData> pendingNotifications = getPendingNotificationUseCase.getPendingNotifications(command).getPendingNotifications();
+        return BaseListResponse.success(pendingNotifications, (long) pendingNotifications.size());
     }
 
     @Operation(

--- a/src/main/java/makeus/cmc/malmo/adaptor/in/web/controller/NotificationController.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/in/web/controller/NotificationController.java
@@ -1,0 +1,84 @@
+package makeus.cmc.malmo.adaptor.in.web.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import makeus.cmc.malmo.adaptor.in.web.docs.ApiCommonResponses;
+import makeus.cmc.malmo.adaptor.in.web.docs.SwaggerResponses;
+import makeus.cmc.malmo.adaptor.in.web.dto.BaseResponse;
+import makeus.cmc.malmo.application.port.in.notification.GetPendingNotificationUseCase;
+import makeus.cmc.malmo.application.port.in.notification.ProcessReadNotificationsUseCase;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "멤버 알람 관리 API", description = "Member 미조회 알람 관리용 API")
+@Slf4j
+@RestController
+@RequestMapping("/members/notifications")
+@RequiredArgsConstructor
+public class NotificationController {
+
+    private final GetPendingNotificationUseCase getPendingNotificationUseCase;
+    private final ProcessReadNotificationsUseCase processReadNotificationsUseCase;
+
+    @Operation(
+            summary = "멤버 미조회 알림 조회",
+            description = "현재 로그인된 멤버의 미조회 알림을 조회합니다. JWT 토큰이 필요합니다.",
+            security = @SecurityRequirement(name = "Bearer Authentication")
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "멤버 알림 정보 조회 성공",
+            content = @Content(schema = @Schema(implementation = SwaggerResponses.GetPendingMemberNotificationSuccessResponse.class))
+    )
+    @ApiCommonResponses.RequireAuth
+    @GetMapping("/pending")
+    public BaseResponse<GetPendingNotificationUseCase.GetPendingNotificationResponse> getMemberPendingNotification(
+            @AuthenticationPrincipal User user
+    ) {
+        GetPendingNotificationUseCase.GetPendingNotificationCommand command = GetPendingNotificationUseCase.GetPendingNotificationCommand.builder()
+                .userId(Long.valueOf(user.getUsername()))
+                .build();
+        return BaseResponse.success(getPendingNotificationUseCase.getPendingNotifications(command));
+    }
+
+    @Operation(
+            summary = "멤버 미조회 알림 조회 처리",
+            description = "현재 로그인된 멤버의 미조회 알림을 조회 처리합니다. JWT 토큰이 필요합니다.",
+            security = @SecurityRequirement(name = "Bearer Authentication")
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "멤버 알림 정보 조회 처리 성공",
+            content = @Content(schema = @Schema(implementation = SwaggerResponses.ReadMemberNotificationSuccessResponse.class))
+    )
+    @ApiCommonResponses.RequireAuth
+    @PatchMapping("/pending")
+    public BaseResponse processNotifications(
+            @AuthenticationPrincipal User user,
+            @RequestBody ProcessNotificationsRequestDto requestDto
+    ) {
+        ProcessReadNotificationsUseCase.ProcessReadNotificationsCommand command = ProcessReadNotificationsUseCase.ProcessReadNotificationsCommand.builder()
+                .userId(Long.valueOf(user.getUsername()))
+                .notificationIds(requestDto.getPendingNotifications())
+                .build();
+
+        processReadNotificationsUseCase.processReadNotifications(command);
+
+        return BaseResponse.success(null);
+    }
+
+    @Data
+    public static class ProcessNotificationsRequestDto {
+        private List<Long> pendingNotifications;
+    }
+}

--- a/src/main/java/makeus/cmc/malmo/adaptor/in/web/docs/SwaggerResponses.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/in/web/docs/SwaggerResponses.java
@@ -1,18 +1,20 @@
 package makeus.cmc.malmo.adaptor.in.web.docs;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Data;
 import lombok.Getter;
+import makeus.cmc.malmo.application.port.in.notification.GetPendingNotificationUseCase;
 import makeus.cmc.malmo.domain.value.state.ChatRoomState;
 import makeus.cmc.malmo.domain.value.state.MemberState;
+import makeus.cmc.malmo.domain.value.state.NotificationState;
 import makeus.cmc.malmo.domain.value.state.TermsDetailsType;
-import makeus.cmc.malmo.domain.value.type.LoveTypeCategory;
-import makeus.cmc.malmo.domain.value.type.Provider;
-import makeus.cmc.malmo.domain.value.type.SenderType;
-import makeus.cmc.malmo.domain.value.type.TermsType;
+import makeus.cmc.malmo.domain.value.type.*;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 
 public class SwaggerResponses {
 
@@ -94,6 +96,16 @@ public class SwaggerResponses {
     @Getter
     @Schema(description = "멤버 약관 동의 수정 성공 응답")
     public static class UpdateMemberTermsSuccessResponse extends BaseSwaggerResponse<BaseListSwaggerResponse<TermsData>> {
+    }
+
+    @Getter
+    @Schema(description = "멤버 미조회 알림 조회 성공 응답")
+    public static class GetPendingMemberNotificationSuccessResponse extends BaseSwaggerResponse<BaseListSwaggerResponse<PendingNotificationData>> {
+    }
+
+    @Getter
+    @Schema(description = "멤버 미조회 알림 조회 처리 성공 응답")
+    public static class ReadMemberNotificationSuccessResponse extends BaseSwaggerResponse<Void> {
     }
 
     @Getter
@@ -287,6 +299,25 @@ public class SwaggerResponses {
 
         @Schema(description = "이메일", example = "test@example.com")
         private String email;
+    }
+
+    @Data
+    @Builder
+    public static class PendingNotificationData {
+        @Schema(description = "알림 ID", example = "1")
+        private Long id;
+
+        @Schema(description = "알림 타입", example = "COUPLE_DISCONNECTED")
+        private NotificationType type;
+
+        @Schema(description = "알림 상태", example = "PENDING")
+        private NotificationState state;
+
+        @Schema(description = "알림 세부사항", example = "알람 마다 다른 내용이 들어갑니다.")
+        private Map<String, Object> payload;
+
+        @Schema(description = "알림 생성시간", example = "2023-07-03T10:00:00")
+        private LocalDateTime createdAt;
     }
 
     @Getter

--- a/src/main/java/makeus/cmc/malmo/adaptor/in/web/security/JwtAuthenticationFilter.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/in/web/security/JwtAuthenticationFilter.java
@@ -74,6 +74,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             return true;
         }
 
+        if (request.getRequestURI().equals("/actuator/prometheus")) {
+            // Prometheus 엔드포인트는 필터링하지 않음
+            return true;
+        }
+
         log.info("[{}] [{} {}] REQUEST_ID : {}", LocalDateTime.now(), request.getMethod(), request.getRequestURI(), MDC.get("request_id"));
 
         String path = request.getRequestURI();
@@ -85,7 +90,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 path.startsWith("/login") ||
                 path.equals("/refresh") ||
                 path.equals("/terms") ||
-                path.equals("/actuator/prometheus") ||
                 path.equals("/love-types") ||
                 path.equals("/test");
         

--- a/src/main/java/makeus/cmc/malmo/adaptor/out/SseEmitterAdapter.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/out/SseEmitterAdapter.java
@@ -3,8 +3,9 @@ package makeus.cmc.malmo.adaptor.out;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import makeus.cmc.malmo.adaptor.out.exception.SseConnectionException;
-import makeus.cmc.malmo.application.port.out.ConnectSsePort;
-import makeus.cmc.malmo.application.port.out.SendSseEventPort;
+import makeus.cmc.malmo.application.port.out.sse.ConnectSsePort;
+import makeus.cmc.malmo.application.port.out.sse.SendSseEventPort;
+import makeus.cmc.malmo.application.port.out.sse.ValidateSsePort;
 import makeus.cmc.malmo.domain.value.id.MemberId;
 import makeus.cmc.malmo.metric.SseMetrics;
 import org.springframework.stereotype.Component;
@@ -17,7 +18,7 @@ import java.util.concurrent.ConcurrentHashMap;
 @Slf4j
 @RequiredArgsConstructor
 @Component
-public class SseEmitterAdapter implements SendSseEventPort, ConnectSsePort {
+public class SseEmitterAdapter implements SendSseEventPort, ConnectSsePort, ValidateSsePort {
     private static final long TIMEOUT = 60 * 1000L; // 1분
     private static final int MAX_SIZE = 1000;
     public static final long RECONNECT_TIME_MILLIS = 3000L;
@@ -89,5 +90,10 @@ public class SseEmitterAdapter implements SendSseEventPort, ConnectSsePort {
             log.error("Failed to send SSE event to member: {}. Removing emitter.", memberIdValue, e);
             emitter.complete();
         }
+    }
+
+    @Override
+    public boolean isMemberOnline(MemberId memberId) {
+        return emitters.containsKey(memberId.getValue());
     }
 }

--- a/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/adapter/MemberNotificationPersistenceAdapter.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/adapter/MemberNotificationPersistenceAdapter.java
@@ -1,0 +1,47 @@
+package makeus.cmc.malmo.adaptor.out.persistence.adapter;
+
+import lombok.RequiredArgsConstructor;
+import makeus.cmc.malmo.adaptor.out.persistence.entity.notification.MemberNotificationEntity;
+import makeus.cmc.malmo.adaptor.out.persistence.mapper.MemberNotificationMapper;
+import makeus.cmc.malmo.adaptor.out.persistence.repository.notification.MemberNotificationRepository;
+import makeus.cmc.malmo.application.port.out.notification.LoadNotificationPort;
+import makeus.cmc.malmo.application.port.out.notification.SaveNotificationPort;
+import makeus.cmc.malmo.domain.model.notification.MemberNotification;
+import makeus.cmc.malmo.domain.value.id.MemberId;
+import makeus.cmc.malmo.domain.value.state.NotificationState;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class MemberNotificationPersistenceAdapter implements LoadNotificationPort, SaveNotificationPort {
+
+    private final MemberNotificationRepository memberNotificationRepository;
+    private final MemberNotificationMapper memberNotificationMapper;
+
+    @Override
+    public List<MemberNotification> getNotificationsByMemberIdAndState(MemberId memberId, NotificationState state) {
+        return memberNotificationRepository.findByMemberIdAndState(memberId.getValue(), state)
+                .stream()
+                .map(memberNotificationMapper::toDomain)
+                .toList();
+    }
+
+    @Override
+    public boolean validateAllNotificationsOwnership(MemberId memberId, List<Long> notificationIds) {
+        return memberNotificationRepository.areAllNotificationsBelongToMember(notificationIds, memberId.getValue(), notificationIds.size());
+    }
+
+    @Override
+    public MemberNotification saveNotification(MemberNotification memberNotification) {
+        MemberNotificationEntity entity = memberNotificationMapper.toEntity(memberNotification);
+        MemberNotificationEntity savedEntity = memberNotificationRepository.save(entity);
+        return memberNotificationMapper.toDomain(savedEntity);
+    }
+
+    @Override
+    public void readNotifications(List<Long> notificationIds) {
+        memberNotificationRepository.readNotifications(notificationIds);
+    }
+}

--- a/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/entity/AESGCMConverter.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/entity/AESGCMConverter.java
@@ -1,0 +1,73 @@
+package makeus.cmc.malmo.adaptor.out.persistence.entity;
+
+import jakarta.persistence.AttributeConverter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.Cipher;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import java.util.Base64;
+import java.security.SecureRandom;
+
+@Component
+public class AESGCMConverter implements AttributeConverter<String, String> {
+
+    private static final String ALGORITHM = "AES/GCM/NoPadding";
+    private static final int GCM_TAG_LENGTH = 128; // bits
+    private static final int IV_LENGTH = 12;       // bytes (권장 12)
+
+    private SecretKey secretKey;
+
+    public AESGCMConverter(@Value("${encryption.aes.key}") String key) {
+        this.secretKey = new SecretKeySpec(key.getBytes(), "AES");
+    }
+
+    @Override
+    public String convertToDatabaseColumn(String attribute) {
+        if (attribute == null) return null;
+        try {
+            byte[] iv = new byte[IV_LENGTH];
+            new SecureRandom().nextBytes(iv); // 매번 랜덤 IV 생성
+
+            Cipher cipher = Cipher.getInstance(ALGORITHM);
+            GCMParameterSpec spec = new GCMParameterSpec(GCM_TAG_LENGTH, iv);
+            cipher.init(Cipher.ENCRYPT_MODE, secretKey, spec);
+
+            byte[] encrypted = cipher.doFinal(attribute.getBytes());
+
+            // IV + Ciphertext 합쳐서 Base64 저장
+            byte[] result = new byte[iv.length + encrypted.length];
+            System.arraycopy(iv, 0, result, 0, iv.length);
+            System.arraycopy(encrypted, 0, result, iv.length, encrypted.length);
+
+            return Base64.getEncoder().encodeToString(result);
+        } catch (Exception e) {
+            throw new RuntimeException("AES-GCM 암호화 실패", e);
+        }
+    }
+
+    @Override
+    public String convertToEntityAttribute(String dbData) {
+        if (dbData == null) return null;
+        try {
+            byte[] decoded = Base64.getDecoder().decode(dbData);
+
+            // 저장된 데이터에서 IV 분리
+            byte[] iv = new byte[IV_LENGTH];
+            byte[] encrypted = new byte[decoded.length - IV_LENGTH];
+            System.arraycopy(decoded, 0, iv, 0, IV_LENGTH);
+            System.arraycopy(decoded, IV_LENGTH, encrypted, 0, encrypted.length);
+
+            Cipher cipher = Cipher.getInstance(ALGORITHM);
+            GCMParameterSpec spec = new GCMParameterSpec(GCM_TAG_LENGTH, iv);
+            cipher.init(Cipher.DECRYPT_MODE, secretKey, spec);
+
+            byte[] decrypted = cipher.doFinal(encrypted);
+            return new String(decrypted);
+        } catch (Exception e) {
+            throw new RuntimeException("AES-GCM 복호화 실패", e);
+        }
+    }
+}

--- a/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/entity/AESGCMConverter.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/entity/AESGCMConverter.java
@@ -44,7 +44,9 @@ public class AESGCMConverter implements AttributeConverter<String, String> {
 
             return Base64.getEncoder().encodeToString(result);
         } catch (Exception e) {
-            throw new RuntimeException("AES-GCM 암호화 실패", e);
+            // 암호화 도입 이전 데이터도 정상 처리
+            return attribute;
+//            throw new RuntimeException("AES-GCM 암호화 실패", e);
         }
     }
 

--- a/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/entity/chat/ChatMessageEntity.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/entity/chat/ChatMessageEntity.java
@@ -5,6 +5,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import makeus.cmc.malmo.adaptor.out.persistence.entity.AESGCMConverter;
 import makeus.cmc.malmo.adaptor.out.persistence.entity.BaseTimeEntity;
 import makeus.cmc.malmo.adaptor.out.persistence.entity.value.ChatRoomEntityId;
 import makeus.cmc.malmo.domain.value.type.SenderType;
@@ -24,6 +25,7 @@ public class ChatMessageEntity extends BaseTimeEntity {
     private ChatRoomEntityId chatRoomEntityId;
 
     @Column(columnDefinition = "TEXT")
+    @Convert(converter = AESGCMConverter.class)
     private String content;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/entity/notification/MemberNotificationEntity.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/entity/notification/MemberNotificationEntity.java
@@ -1,0 +1,40 @@
+package makeus.cmc.malmo.adaptor.out.persistence.entity.notification;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import makeus.cmc.malmo.adaptor.out.persistence.entity.BaseTimeEntity;
+import makeus.cmc.malmo.adaptor.out.persistence.entity.value.MemberEntityId;
+import makeus.cmc.malmo.domain.value.state.NotificationState;
+import makeus.cmc.malmo.domain.value.type.NotificationType;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.util.Map;
+
+@Getter
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class MemberNotificationEntity extends BaseTimeEntity {
+
+    @Column(name = "memberNotificationId")
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Embedded
+    private MemberEntityId memberId;
+
+    @Enumerated(value = EnumType.STRING)
+    private NotificationType type;
+
+    @Enumerated(value = EnumType.STRING)
+    private NotificationState state;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(columnDefinition = "json")
+    private Map<String, Object> payload;
+}

--- a/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/mapper/MemberNotificationMapper.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/mapper/MemberNotificationMapper.java
@@ -1,0 +1,37 @@
+package makeus.cmc.malmo.adaptor.out.persistence.mapper;
+
+import makeus.cmc.malmo.adaptor.out.persistence.entity.notification.MemberNotificationEntity;
+import makeus.cmc.malmo.adaptor.out.persistence.entity.value.MemberEntityId;
+import makeus.cmc.malmo.domain.model.notification.MemberNotification;
+import makeus.cmc.malmo.domain.value.id.MemberId;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MemberNotificationMapper {
+
+    public MemberNotification toDomain(MemberNotificationEntity entity) {
+        return MemberNotification.from(
+                entity.getId(),
+                entity.getMemberId() == null ? null : MemberId.of(entity.getMemberId().getValue()),
+                entity.getType(),
+                entity.getState(),
+                entity.getPayload(),
+                entity.getCreatedAt(),
+                entity.getModifiedAt(),
+                entity.getDeletedAt()
+        );
+    }
+
+    public MemberNotificationEntity toEntity(MemberNotification domain) {
+        return MemberNotificationEntity.builder()
+                .id(domain.getId())
+                .memberId(domain.getMemberId() == null ? null : MemberEntityId.of(domain.getMemberId().getValue()))
+                .type(domain.getType())
+                .state(domain.getState())
+                .payload(domain.getPayload())
+                .createdAt(domain.getCreatedAt())
+                .modifiedAt(domain.getModifiedAt())
+                .deletedAt(domain.getDeletedAt())
+                .build();
+    }
+}

--- a/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/repository/member/MemberRepository.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/repository/member/MemberRepository.java
@@ -14,7 +14,7 @@ public interface MemberRepository extends JpaRepository<MemberEntity, Long>, Mem
 
     Optional<MemberEntity> findByProviderAndProviderId(Provider providerJpa, String providerId);
 
-    @Query("select m from MemberEntity m where m.inviteCodeEntityValue.value = ?1 and m.memberState = 'ALIVE'")
+    @Query("select m from MemberEntity m where m.inviteCodeEntityValue.value = ?1 and m.memberState != 'DELETED'")
     Optional<MemberEntity> findMemberEntityByInviteCode(String inviteCode);
 
     @Query("select m.coupleEntityId.value from MemberEntity m where m.id = ?1 and m.memberState != 'DELETED'")

--- a/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/repository/notification/MemberNotificationRepository.java
+++ b/src/main/java/makeus/cmc/malmo/adaptor/out/persistence/repository/notification/MemberNotificationRepository.java
@@ -1,0 +1,27 @@
+package makeus.cmc.malmo.adaptor.out.persistence.repository.notification;
+
+import makeus.cmc.malmo.adaptor.out.persistence.entity.notification.MemberNotificationEntity;
+import makeus.cmc.malmo.domain.value.state.NotificationState;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+public interface MemberNotificationRepository extends JpaRepository<MemberNotificationEntity, Long> {
+
+    @Query("select m from MemberNotificationEntity m where m.memberId.value = ?1 and m.state = ?2")
+    List<MemberNotificationEntity> findByMemberIdAndState(Long memberId, NotificationState state);
+
+    @Modifying
+    @Transactional
+    @Query("update MemberNotificationEntity m set m.state = 'READ' where m.id in ?1")
+    void readNotifications(List<Long> notificationIds);
+
+    @Query("select case when count(m) = ?3 then true else false end " +
+            "from MemberNotificationEntity m " +
+            "where m.id in ?1 and m.memberId.value = ?2")
+    boolean areAllNotificationsBelongToMember(List<Long> notificationIds, Long memberId, long size);
+}

--- a/src/main/java/makeus/cmc/malmo/application/helper/notification/MemberNotificationCommandHelper.java
+++ b/src/main/java/makeus/cmc/malmo/application/helper/notification/MemberNotificationCommandHelper.java
@@ -1,0 +1,42 @@
+package makeus.cmc.malmo.application.helper.notification;
+
+import lombok.RequiredArgsConstructor;
+import makeus.cmc.malmo.application.port.out.notification.SaveNotificationPort;
+import makeus.cmc.malmo.domain.model.notification.MemberNotification;
+import makeus.cmc.malmo.domain.value.id.MemberId;
+import makeus.cmc.malmo.domain.value.state.NotificationState;
+import makeus.cmc.malmo.domain.value.type.NotificationType;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+
+@RequiredArgsConstructor
+@Component
+public class MemberNotificationCommandHelper {
+
+    private final SaveNotificationPort saveNotificationPort;
+
+    public MemberNotification createAndSaveCoupleDisconnectedNotification(MemberId memberId) {
+        return createAndSavePendingNotification(memberId, NotificationType.COUPLE_DISCONNECTED, null);
+    }
+
+    private MemberNotification createAndSavePendingNotification(MemberId memberId, NotificationType type, Map<String, Object> payload) {
+        MemberNotification memberNotification = MemberNotification.createMemberNotification(
+                memberId,
+                type,
+                NotificationState.PENDING,
+                payload
+        );
+
+        return saveNotificationPort.saveNotification(memberNotification);
+    }
+
+    public void markNotificationsAsRead(List<Long> notificationIds) {
+        saveNotificationPort.readNotifications(notificationIds);
+    }
+
+    public MemberNotification createAndSaveCoupleConnectedNotification(MemberId memberId) {
+        return createAndSavePendingNotification(memberId, NotificationType.COUPLE_CONNECTED, null);
+    }
+}

--- a/src/main/java/makeus/cmc/malmo/application/helper/notification/MemberNotificationQueryHelper.java
+++ b/src/main/java/makeus/cmc/malmo/application/helper/notification/MemberNotificationQueryHelper.java
@@ -1,0 +1,32 @@
+package makeus.cmc.malmo.application.helper.notification;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import makeus.cmc.malmo.application.exception.MemberAccessDeniedException;
+import makeus.cmc.malmo.application.port.out.notification.LoadNotificationPort;
+import makeus.cmc.malmo.domain.model.notification.MemberNotification;
+import makeus.cmc.malmo.domain.value.id.MemberId;
+import makeus.cmc.malmo.domain.value.state.NotificationState;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class MemberNotificationQueryHelper {
+
+    private final LoadNotificationPort loadNotificationPort;
+
+    public List<MemberNotification> getAllPendingNotifications(MemberId memberId) {
+        return loadNotificationPort.getNotificationsByMemberIdAndState(memberId, NotificationState.PENDING);
+    }
+
+    public void validateMemberNotifications(List<Long> notificationIds, MemberId memberId) {
+        boolean isValid = loadNotificationPort.validateAllNotificationsOwnership(memberId, notificationIds);
+
+        if (!isValid) {
+            throw new MemberAccessDeniedException("해당 알림에 접근 권한이 없습니다.");
+        }
+    }
+}

--- a/src/main/java/makeus/cmc/malmo/application/port/in/notification/GetPendingNotificationUseCase.java
+++ b/src/main/java/makeus/cmc/malmo/application/port/in/notification/GetPendingNotificationUseCase.java
@@ -1,0 +1,38 @@
+package makeus.cmc.malmo.application.port.in.notification;
+
+import lombok.Builder;
+import lombok.Data;
+import makeus.cmc.malmo.domain.value.state.NotificationState;
+import makeus.cmc.malmo.domain.value.type.NotificationType;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+public interface GetPendingNotificationUseCase {
+
+    GetPendingNotificationResponse getPendingNotifications(GetPendingNotificationCommand command);
+
+
+    @Data
+    @Builder
+    class GetPendingNotificationResponse {
+        private List<PendingNotificationData> pendingNotifications;
+    }
+
+    @Data
+    @Builder
+    class PendingNotificationData {
+        private Long id;
+        private NotificationType type;
+        private NotificationState state;
+        private Map<String, Object> payload;
+        private LocalDateTime createdAt;
+    }
+
+    @Data
+    @Builder
+    class GetPendingNotificationCommand {
+        private Long userId;
+    }
+}

--- a/src/main/java/makeus/cmc/malmo/application/port/in/notification/ProcessReadNotificationsUseCase.java
+++ b/src/main/java/makeus/cmc/malmo/application/port/in/notification/ProcessReadNotificationsUseCase.java
@@ -1,0 +1,18 @@
+package makeus.cmc.malmo.application.port.in.notification;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+
+public interface ProcessReadNotificationsUseCase {
+
+    void processReadNotifications(ProcessReadNotificationsCommand command);
+
+    @Data
+    @Builder
+    class ProcessReadNotificationsCommand {
+        private Long userId;
+        private List<Long> notificationIds;
+    }
+}

--- a/src/main/java/makeus/cmc/malmo/application/port/out/notification/LoadNotificationPort.java
+++ b/src/main/java/makeus/cmc/malmo/application/port/out/notification/LoadNotificationPort.java
@@ -1,0 +1,14 @@
+package makeus.cmc.malmo.application.port.out.notification;
+
+import makeus.cmc.malmo.domain.model.notification.MemberNotification;
+import makeus.cmc.malmo.domain.value.id.MemberId;
+import makeus.cmc.malmo.domain.value.state.NotificationState;
+
+import java.util.List;
+
+public interface LoadNotificationPort {
+
+    List<MemberNotification> getNotificationsByMemberIdAndState(MemberId memberId, NotificationState state);
+
+    boolean validateAllNotificationsOwnership(MemberId memberId, List<Long> notificationIds);
+}

--- a/src/main/java/makeus/cmc/malmo/application/port/out/notification/SaveNotificationPort.java
+++ b/src/main/java/makeus/cmc/malmo/application/port/out/notification/SaveNotificationPort.java
@@ -1,0 +1,12 @@
+package makeus.cmc.malmo.application.port.out.notification;
+
+import makeus.cmc.malmo.domain.model.notification.MemberNotification;
+
+import java.util.List;
+
+public interface SaveNotificationPort {
+
+    MemberNotification saveNotification(MemberNotification memberNotification);
+
+    void readNotifications(List<Long> notificationIds);
+}

--- a/src/main/java/makeus/cmc/malmo/application/port/out/sse/ConnectSsePort.java
+++ b/src/main/java/makeus/cmc/malmo/application/port/out/sse/ConnectSsePort.java
@@ -1,4 +1,4 @@
-package makeus.cmc.malmo.application.port.out;
+package makeus.cmc.malmo.application.port.out.sse;
 
 import makeus.cmc.malmo.domain.value.id.MemberId;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;

--- a/src/main/java/makeus/cmc/malmo/application/port/out/sse/SendSseEventPort.java
+++ b/src/main/java/makeus/cmc/malmo/application/port/out/sse/SendSseEventPort.java
@@ -1,4 +1,4 @@
-package makeus.cmc.malmo.application.port.out;
+package makeus.cmc.malmo.application.port.out.sse;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/makeus/cmc/malmo/application/port/out/sse/ValidateSsePort.java
+++ b/src/main/java/makeus/cmc/malmo/application/port/out/sse/ValidateSsePort.java
@@ -1,0 +1,7 @@
+package makeus.cmc.malmo.application.port.out.sse;
+
+import makeus.cmc.malmo.domain.value.id.MemberId;
+
+public interface ValidateSsePort {
+    boolean isMemberOnline(MemberId memberId);
+}

--- a/src/main/java/makeus/cmc/malmo/application/service/SseService.java
+++ b/src/main/java/makeus/cmc/malmo/application/service/SseService.java
@@ -2,7 +2,7 @@ package makeus.cmc.malmo.application.service;
 
 import lombok.RequiredArgsConstructor;
 import makeus.cmc.malmo.application.port.in.ConnectSseUseCase;
-import makeus.cmc.malmo.application.port.out.ConnectSsePort;
+import makeus.cmc.malmo.application.port.out.sse.ConnectSsePort;
 import makeus.cmc.malmo.domain.value.id.MemberId;
 import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;

--- a/src/main/java/makeus/cmc/malmo/application/service/chat/ChatMessageService.java
+++ b/src/main/java/makeus/cmc/malmo/application/service/chat/ChatMessageService.java
@@ -9,7 +9,7 @@ import makeus.cmc.malmo.application.helper.member.MemberMemoryCommandHelper;
 import makeus.cmc.malmo.application.helper.member.MemberQueryHelper;
 import makeus.cmc.malmo.application.helper.question.CoupleQuestionQueryHelper;
 import makeus.cmc.malmo.application.port.in.chat.ProcessMessageUseCase;
-import makeus.cmc.malmo.application.port.out.SendSseEventPort;
+import makeus.cmc.malmo.application.port.out.sse.SendSseEventPort;
 import makeus.cmc.malmo.application.port.out.chat.SaveChatMessageSummaryPort;
 import makeus.cmc.malmo.application.port.out.member.ValidateMemberPort;
 import makeus.cmc.malmo.domain.model.chat.ChatMessage;

--- a/src/main/java/makeus/cmc/malmo/application/service/chat/ChatSseSender.java
+++ b/src/main/java/makeus/cmc/malmo/application/service/chat/ChatSseSender.java
@@ -1,7 +1,7 @@
 package makeus.cmc.malmo.application.service.chat;
 
 import lombok.RequiredArgsConstructor;
-import makeus.cmc.malmo.application.port.out.SendSseEventPort;
+import makeus.cmc.malmo.application.port.out.sse.SendSseEventPort;
 import makeus.cmc.malmo.domain.value.id.MemberId;
 import org.springframework.stereotype.Service;
 

--- a/src/main/java/makeus/cmc/malmo/application/service/couple/CoupleService.java
+++ b/src/main/java/makeus/cmc/malmo/application/service/couple/CoupleService.java
@@ -214,6 +214,6 @@ public class CoupleService implements CoupleLinkUseCase, CoupleUnlinkUseCase {
         } else {
             memberNotificationCommandHelper.createAndSaveCoupleConnectedNotification(partnerId);
         }
-        
+
     }
 }

--- a/src/main/java/makeus/cmc/malmo/application/service/couple/CoupleService.java
+++ b/src/main/java/makeus/cmc/malmo/application/service/couple/CoupleService.java
@@ -10,11 +10,13 @@ import makeus.cmc.malmo.application.helper.couple.CoupleQueryHelper;
 import makeus.cmc.malmo.application.helper.member.MemberCommandHelper;
 import makeus.cmc.malmo.application.helper.member.MemberMemoryCommandHelper;
 import makeus.cmc.malmo.application.helper.member.MemberQueryHelper;
+import makeus.cmc.malmo.application.helper.notification.MemberNotificationCommandHelper;
 import makeus.cmc.malmo.application.helper.question.CoupleQuestionCommandHelper;
 import makeus.cmc.malmo.application.helper.question.CoupleQuestionQueryHelper;
 import makeus.cmc.malmo.application.port.in.couple.CoupleLinkUseCase;
 import makeus.cmc.malmo.application.port.in.couple.CoupleUnlinkUseCase;
-import makeus.cmc.malmo.application.port.out.SendSseEventPort;
+import makeus.cmc.malmo.application.port.out.sse.SendSseEventPort;
+import makeus.cmc.malmo.application.port.out.sse.ValidateSsePort;
 import makeus.cmc.malmo.domain.model.couple.Couple;
 import makeus.cmc.malmo.domain.model.member.Member;
 import makeus.cmc.malmo.domain.model.question.CoupleQuestion;
@@ -30,8 +32,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 
-import static makeus.cmc.malmo.application.port.out.SendSseEventPort.SseEventType.COUPLE_CONNECTED;
-import static makeus.cmc.malmo.application.port.out.SendSseEventPort.SseEventType.COUPLE_DISCONNECTED;
+import static makeus.cmc.malmo.application.port.out.sse.SendSseEventPort.SseEventType.COUPLE_CONNECTED;
+import static makeus.cmc.malmo.application.port.out.sse.SendSseEventPort.SseEventType.COUPLE_DISCONNECTED;
 import static makeus.cmc.malmo.util.GlobalConstants.FIRST_QUESTION_LEVEL;
 
 @Service
@@ -48,11 +50,14 @@ public class CoupleService implements CoupleLinkUseCase, CoupleUnlinkUseCase {
     private final MemberQueryHelper memberQueryHelper;
 
     private final SendSseEventPort sendSseEventPort;
+    private final ValidateSsePort validateSsePort;
+
     private final ChatRoomQueryHelper chatRoomQueryHelper;
     private final ChatRoomCommandHelper chatRoomCommandHelper;
 
     private final MemberMemoryCommandHelper memberMemoryCommandHelper;
     private final MemberCommandHelper memberCommandHelper;
+    private final MemberNotificationCommandHelper memberNotificationCommandHelper;
 
     @Override
     @CheckValidMember
@@ -126,9 +131,15 @@ public class CoupleService implements CoupleLinkUseCase, CoupleUnlinkUseCase {
         memberCommandHelper.saveMember(member);
 
         // 상대방에게 커플 해지됨 알림
-        sendSseEventPort.sendToMember(partnerId,
-                new SendSseEventPort.NotificationEvent(COUPLE_DISCONNECTED, couple.getId())
-        );
+        if (validateSsePort.isMemberOnline(partnerId)) {
+            sendSseEventPort.sendToMember(partnerId,
+                    new SendSseEventPort.NotificationEvent(COUPLE_DISCONNECTED, couple.getId())
+            );
+        } else {
+            // 상대방이 온라인이 아닐 경우 알림 생성
+            memberNotificationCommandHelper.createAndSaveCoupleDisconnectedNotification(partnerId);
+        }
+
     }
 
     private Couple reconnectCouple(Couple brokenCouple) {
@@ -195,9 +206,14 @@ public class CoupleService implements CoupleLinkUseCase, CoupleUnlinkUseCase {
                         }
                 );
 
-        sendSseEventPort.sendToMember(
-                partnerId,
-                new SendSseEventPort.NotificationEvent(COUPLE_CONNECTED, couple.getId())
-        );
+        if (validateSsePort.isMemberOnline(partnerId)) {
+            sendSseEventPort.sendToMember(
+                    partnerId,
+                    new SendSseEventPort.NotificationEvent(COUPLE_CONNECTED, couple.getId())
+            );
+        } else {
+            memberNotificationCommandHelper.createAndSaveCoupleConnectedNotification(partnerId);
+        }
+        
     }
 }

--- a/src/main/java/makeus/cmc/malmo/application/service/notification/NotificationService.java
+++ b/src/main/java/makeus/cmc/malmo/application/service/notification/NotificationService.java
@@ -1,0 +1,51 @@
+package makeus.cmc.malmo.application.service.notification;
+
+import lombok.RequiredArgsConstructor;
+import makeus.cmc.malmo.adaptor.in.aop.CheckValidMember;
+import makeus.cmc.malmo.application.helper.notification.MemberNotificationCommandHelper;
+import makeus.cmc.malmo.application.helper.notification.MemberNotificationQueryHelper;
+import makeus.cmc.malmo.application.port.in.notification.GetPendingNotificationUseCase;
+import makeus.cmc.malmo.application.port.in.notification.ProcessReadNotificationsUseCase;
+import makeus.cmc.malmo.domain.model.notification.MemberNotification;
+import makeus.cmc.malmo.domain.value.id.MemberId;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationService implements GetPendingNotificationUseCase, ProcessReadNotificationsUseCase {
+
+    private final MemberNotificationQueryHelper memberNotificationQueryHelper;
+    private final MemberNotificationCommandHelper memberNotificationCommandHelper;
+
+    @Override
+    @CheckValidMember
+    public GetPendingNotificationResponse getPendingNotifications(GetPendingNotificationCommand command) {
+        List<MemberNotification> pendingNotifications = memberNotificationQueryHelper.getAllPendingNotifications(MemberId.of(command.getUserId()));
+
+        List<PendingNotificationData> notificationDataList = pendingNotifications.stream()
+                .map(notification ->
+                        PendingNotificationData.builder()
+                                .id(notification.getId())
+                                .type(notification.getType())
+                                .state(notification.getState())
+                                .payload(notification.getPayload())
+                                .createdAt(notification.getCreatedAt())
+                                .build()).toList();
+
+        return GetPendingNotificationResponse.builder()
+                .pendingNotifications(notificationDataList)
+                .build();
+    }
+
+    @Override
+    @CheckValidMember
+    public void processReadNotifications(ProcessReadNotificationsCommand command) {
+        // 알림에 대한 접근 권한 확인
+        memberNotificationQueryHelper.validateMemberNotifications(command.getNotificationIds(), MemberId.of(command.getUserId()));
+
+        // 알림을 읽음 상태로 변경
+        memberNotificationCommandHelper.markNotificationsAsRead(command.getNotificationIds());
+    }
+}

--- a/src/main/java/makeus/cmc/malmo/domain/model/notification/MemberNotification.java
+++ b/src/main/java/makeus/cmc/malmo/domain/model/notification/MemberNotification.java
@@ -1,0 +1,62 @@
+package makeus.cmc.malmo.domain.model.notification;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import makeus.cmc.malmo.domain.value.id.MemberId;
+import makeus.cmc.malmo.domain.value.state.NotificationState;
+import makeus.cmc.malmo.domain.value.type.NotificationType;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+public class MemberNotification {
+    private Long id;
+    private MemberId memberId;
+    private NotificationType type;
+    private NotificationState state;
+    private Map<String, Object> payload;
+
+    // BaseTimeEntity fields
+    private LocalDateTime createdAt;
+    private LocalDateTime modifiedAt;
+    private LocalDateTime deletedAt;
+
+    public static MemberNotification createMemberNotification(
+            MemberId memberId,
+            NotificationType type,
+            NotificationState state,
+            Map<String, Object> payload) {
+
+        return MemberNotification.builder()
+                .memberId(memberId)
+                .type(type)
+                .state(state)
+                .payload(payload)
+                .build();
+    }
+
+    public static MemberNotification from(
+            Long id,
+            MemberId memberId,
+            NotificationType type,
+            NotificationState state,
+            Map<String, Object> payload,
+            LocalDateTime createdAt,
+            LocalDateTime modifiedAt,
+            LocalDateTime deletedAt) {
+
+        return MemberNotification.builder()
+                .id(id)
+                .memberId(memberId)
+                .type(type)
+                .state(state)
+                .payload(payload)
+                .createdAt(createdAt)
+                .modifiedAt(modifiedAt)
+                .deletedAt(deletedAt)
+                .build();
+    }
+}

--- a/src/main/java/makeus/cmc/malmo/domain/value/state/NotificationState.java
+++ b/src/main/java/makeus/cmc/malmo/domain/value/state/NotificationState.java
@@ -1,0 +1,7 @@
+package makeus.cmc.malmo.domain.value.state;
+
+public enum NotificationState {
+    PENDING, // 알림 대기 상태
+    READ,    // 알림 읽음 상태
+    DELETED  // 알림 삭제 상태
+}

--- a/src/main/java/makeus/cmc/malmo/domain/value/type/NotificationType.java
+++ b/src/main/java/makeus/cmc/malmo/domain/value/type/NotificationType.java
@@ -1,0 +1,5 @@
+package makeus.cmc.malmo.domain.value.type;
+
+public enum NotificationType {
+    COUPLE_CONNECTED, COUPLE_DISCONNECTED
+}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -74,3 +74,7 @@ security:
     url:
       production: ${SECURITY_CLIENT_URL_PRODUCTION}
       development: ${SECURITY_CLIENT_URL_DEVELOPMENT}
+
+encryption:
+  aes:
+    key: ${AES_ENCRYPTION_KEY}

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -83,3 +83,7 @@ security:
     url:
       production: test.prod.com
       development:  test.dev.com
+
+encryption:
+  aes:
+    key: testaeskeyrZktAgxX77DA==

--- a/src/test/java/makeus/cmc/malmo/AESGCMConverterTest.java
+++ b/src/test/java/makeus/cmc/malmo/AESGCMConverterTest.java
@@ -1,0 +1,106 @@
+package makeus.cmc.malmo;
+
+import jakarta.persistence.EntityManager;
+import makeus.cmc.malmo.adaptor.out.persistence.entity.AESGCMConverter;
+import makeus.cmc.malmo.adaptor.out.persistence.entity.chat.ChatMessageEntity;
+import makeus.cmc.malmo.adaptor.out.persistence.entity.chat.ChatRoomEntity;
+import makeus.cmc.malmo.adaptor.out.persistence.entity.member.MemberEntity;
+import makeus.cmc.malmo.adaptor.out.persistence.entity.value.ChatRoomEntityId;
+import makeus.cmc.malmo.adaptor.out.persistence.entity.value.InviteCodeEntityValue;
+import makeus.cmc.malmo.adaptor.out.persistence.entity.value.MemberEntityId;
+import makeus.cmc.malmo.domain.value.state.ChatRoomState;
+import makeus.cmc.malmo.domain.value.state.MemberState;
+import makeus.cmc.malmo.domain.value.type.MemberRole;
+import makeus.cmc.malmo.domain.value.type.Provider;
+import makeus.cmc.malmo.domain.value.type.SenderType;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+@Transactional
+@SpringBootTest
+public class AESGCMConverterTest {
+
+    @Autowired
+    private AESGCMConverter aesgcmConverter;
+
+    private MemberEntity member;
+    private ChatRoomEntity chatRoom;
+
+    @Autowired
+    private EntityManager em;
+
+    @BeforeEach
+    void setup() {
+        member = createAndSaveMember("testUser", "test@email.com", "invite1");
+        chatRoom = ChatRoomEntity.builder()
+                .memberEntityId(MemberEntityId.of(member.getId()))
+                .level(1)
+                .chatRoomState(ChatRoomState.ALIVE)
+                .build();
+    }
+
+    @Test
+    void testEncryptionDecryption() {
+        String original = "This is a test message.";
+        String encrypted = aesgcmConverter.convertToDatabaseColumn(original);
+        String decrypted = aesgcmConverter.convertToEntityAttribute(encrypted);
+        Assertions.assertThat(decrypted).isEqualTo(original);
+        Assertions.assertThat(encrypted).isNotEqualTo(original);
+
+        System.out.println("Original: " + original);
+        System.out.println("Encrypted: " + encrypted);
+        System.out.println("Decrypted: " + decrypted);
+    }
+
+    private MemberEntity createAndSaveMember(String nickname, String email, String inviteCode) {
+        MemberEntity memberEntity = MemberEntity.builder()
+                .provider(Provider.KAKAO)
+                .providerId(email) // providerId를 email로 사용
+                .memberRole(MemberRole.MEMBER)
+                .memberState(MemberState.ALIVE)
+                .startLoveDate(LocalDate.of(2023, 1, 1)) // 임의의 연애 시작일
+                .nickname(nickname)
+                .email(email)
+                .inviteCodeEntityValue(InviteCodeEntityValue.of(inviteCode))
+                .build();
+        em.persist(memberEntity);
+        return memberEntity;
+    }
+
+    @Test
+    void testSaveChatMessageEntity() {
+        // Given
+        ChatMessageEntity chatMessage = ChatMessageEntity.builder()
+                .chatRoomEntityId(ChatRoomEntityId.of(chatRoom.getId()))
+                .content("안녕하세요! AI 테스트 메시지입니다.")
+                .level(1)
+                .senderType(SenderType.USER)
+                .build();
+
+        em.persist(chatMessage);
+
+        // When
+        em.flush();
+        em.clear();
+        ChatMessageEntity retrieved = em.find(ChatMessageEntity.class, chatMessage.getId());
+
+        // Then
+        Assertions.assertThat(retrieved).isNotNull();
+        Assertions.assertThat(retrieved.getContent()).isEqualTo(chatMessage.getContent());
+
+        String encryptedContentFromDB = (String) em.createNativeQuery(
+                        "SELECT content FROM chat_message_entity WHERE chat_message_id = ?")
+                .setParameter(1, chatMessage.getId())
+                .getSingleResult();
+
+        Assertions.assertThat(encryptedContentFromDB).isNotEqualTo(chatMessage.getContent());
+        System.out.println("Encrypted content in DB: " + encryptedContentFromDB);
+    }
+
+}

--- a/src/test/java/makeus/cmc/malmo/integration_test/MemberNotificationIntegrationTest.java
+++ b/src/test/java/makeus/cmc/malmo/integration_test/MemberNotificationIntegrationTest.java
@@ -99,7 +99,7 @@ public class MemberNotificationIntegrationTest {
             mockMvc.perform(get("/members/notifications/pending")
                             .header("Authorization", "Bearer " + accessToken))
                     .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.data.pendingNotifications.length()").value(2));
+                    .andExpect(jsonPath("$.data.list.length()").value(2));
         }
     }
 

--- a/src/test/java/makeus/cmc/malmo/integration_test/MemberNotificationIntegrationTest.java
+++ b/src/test/java/makeus/cmc/malmo/integration_test/MemberNotificationIntegrationTest.java
@@ -1,0 +1,200 @@
+package makeus.cmc.malmo.integration_test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.EntityManager;
+import makeus.cmc.malmo.adaptor.in.web.controller.NotificationController;
+import makeus.cmc.malmo.adaptor.out.jwt.TokenInfo;
+import makeus.cmc.malmo.adaptor.out.persistence.entity.member.MemberEntity;
+import makeus.cmc.malmo.adaptor.out.persistence.entity.notification.MemberNotificationEntity;
+import makeus.cmc.malmo.adaptor.out.persistence.entity.value.InviteCodeEntityValue;
+import makeus.cmc.malmo.adaptor.out.persistence.entity.value.MemberEntityId;
+import makeus.cmc.malmo.application.port.out.member.GenerateTokenPort;
+import makeus.cmc.malmo.domain.value.state.MemberState;
+import makeus.cmc.malmo.domain.value.state.NotificationState;
+import makeus.cmc.malmo.domain.value.type.MemberRole;
+import makeus.cmc.malmo.domain.value.type.NotificationType;
+import makeus.cmc.malmo.domain.value.type.Provider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc
+@Transactional
+public class MemberNotificationIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private EntityManager em;
+
+    @Autowired
+    private GenerateTokenPort generateTokenPort;
+
+    private String accessToken;
+    private MemberEntity member;
+
+    @BeforeEach
+    void setup() {
+        member = MemberEntity.builder()
+                .provider(Provider.KAKAO)
+                .providerId("testProviderId")
+                .memberRole(MemberRole.MEMBER)
+                .memberState(MemberState.ALIVE)
+                .email("testEmail@test.com")
+                .nickname("nickname")
+                .startLoveDate(LocalDate.of(2023, 10, 1))
+                .inviteCodeEntityValue(InviteCodeEntityValue.of("testInviteCode"))
+                .build();
+        em.persist(member);
+        em.flush();
+
+        TokenInfo tokenInfo = generateTokenPort.generateToken(member.getId(), member.getMemberRole());
+        accessToken = tokenInfo.getAccessToken();
+    }
+
+    @Nested
+    @DisplayName("멤버 미조회 알림 조회")
+    class GetPendingNotifications {
+
+        @Test
+        @DisplayName("알림이 없는 경우, 빈 리스트를 반환한다.")
+        void getMemberPendingNotification_empty() throws Exception {
+            // when & then
+            mockMvc.perform(get("/members/notifications/pending")
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.notifications").doesNotExist());
+        }
+
+        @Test
+        @DisplayName("알림이 있는 경우, 알림 목록을 반환한다.")
+        void getMemberPendingNotification_success() throws Exception {
+            // given
+            createAndSaveNotification("테스트 알림 1");
+            createAndSaveNotification("테스트 알림 2");
+
+            // when & then
+            mockMvc.perform(get("/members/notifications/pending")
+                            .header("Authorization", "Bearer " + accessToken))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.pendingNotifications.length()").value(2));
+        }
+    }
+
+    @Nested
+    @DisplayName("멤버 미조회 알림 읽기 처리")
+    class ProcessReadNotifications {
+
+        @Test
+        @DisplayName("알림이 있는 경우, 읽기 처리 성공")
+        void processReadNotifications_success() throws Exception {
+            // given
+            MemberNotificationEntity notification1 = createAndSaveNotification("테스트 알림 1");
+            MemberNotificationEntity notification2 = createAndSaveNotification("테스트 알림 2");
+
+            NotificationController.ProcessNotificationsRequestDto requestDto = new NotificationController.ProcessNotificationsRequestDto();
+            requestDto.setPendingNotifications(List.of(notification1.getId(), notification2.getId()));
+
+            // when
+            mockMvc.perform(patch("/members/notifications/pending")
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(requestDto)))
+                    .andExpect(status().isOk());
+
+            // then
+            em.flush();
+            em.clear();
+            MemberNotificationEntity result1 = em.find(MemberNotificationEntity.class, notification1.getId());
+            MemberNotificationEntity result2 = em.find(MemberNotificationEntity.class, notification2.getId());
+            assertThat(result1.getState()).isEqualTo(NotificationState.READ);
+            assertThat(result2.getState()).isEqualTo(NotificationState.READ);
+        }
+
+        @Test
+        @DisplayName("없는 알림 ID를 포함하여 요청하는 경우, 요청이 실패한다.")
+        void processReadNotifications_with_not_exist_id() throws Exception {
+            // given
+            MemberNotificationEntity notification1 = createAndSaveNotification("테스트 알림 1");
+
+            NotificationController.ProcessNotificationsRequestDto requestDto = new NotificationController.ProcessNotificationsRequestDto();
+            requestDto.setPendingNotifications(List.of(notification1.getId(), 999L));
+
+            // when
+            mockMvc.perform(patch("/members/notifications/pending")
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(requestDto)))
+                    .andExpect(status().isForbidden());
+        }
+
+        @Test
+        @DisplayName("알림이 자신의 것이 아닌 경우, 요청이 실패한다.")
+        void processReadNotifications_not_mine() throws Exception {
+            // given
+            MemberEntity otherMember = MemberEntity.builder()
+                    .provider(Provider.KAKAO)
+                    .providerId("otherProviderId")
+                    .memberRole(MemberRole.MEMBER)
+                    .memberState(MemberState.ALIVE)
+                    .email("other@test.com")
+                    .nickname("other")
+                    .inviteCodeEntityValue(InviteCodeEntityValue.of("otherInviteCode"))
+                    .build();
+            em.persist(otherMember);
+            em.flush();
+
+            MemberNotificationEntity myNotification = createAndSaveNotification("내 알림");
+            MemberNotificationEntity otherNotification = createAndSaveNotificationForMember("다른 사람 알림", otherMember);
+
+
+            NotificationController.ProcessNotificationsRequestDto requestDto = new NotificationController.ProcessNotificationsRequestDto();
+            requestDto.setPendingNotifications(List.of(myNotification.getId(), otherNotification.getId()));
+
+            // when
+            mockMvc.perform(patch("/members/notifications/pending")
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(requestDto)))
+                    .andExpect(status().isForbidden());
+        }
+    }
+
+    private MemberNotificationEntity createAndSaveNotification(String message) {
+        return createAndSaveNotificationForMember(message, this.member);
+    }
+
+    private MemberNotificationEntity createAndSaveNotificationForMember(String message, MemberEntity member) {
+        MemberNotificationEntity notification = MemberNotificationEntity.builder()
+                .memberId(MemberEntityId.of(member.getId()))
+                .payload(Map.of("message", message))
+                .state(NotificationState.PENDING)
+                .type(NotificationType.COUPLE_DISCONNECTED)
+                .build();
+        em.persist(notification);
+        em.flush();
+        return notification;
+    }
+}

--- a/src/test/java/makeus/cmc/malmo/mapper/ChatMessageMapperTest.java
+++ b/src/test/java/makeus/cmc/malmo/mapper/ChatMessageMapperTest.java
@@ -1,0 +1,95 @@
+package makeus.cmc.malmo.mapper;
+
+import makeus.cmc.malmo.adaptor.out.persistence.entity.chat.ChatMessageEntity;
+import makeus.cmc.malmo.adaptor.out.persistence.entity.value.ChatRoomEntityId;
+import makeus.cmc.malmo.adaptor.out.persistence.mapper.ChatMessageMapper;
+import makeus.cmc.malmo.domain.model.chat.ChatMessage;
+import makeus.cmc.malmo.domain.value.id.ChatRoomId;
+import makeus.cmc.malmo.domain.value.type.SenderType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ChatMessageMapper 테스트")
+class ChatMessageMapperTest {
+
+    @InjectMocks
+    private ChatMessageMapper chatMessageMapper;
+
+    @Test
+    @DisplayName("ChatMessageEntity를 ChatMessage Domain으로 변환한다")
+    void toDomain() {
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        ChatMessageEntity entity = ChatMessageEntity.builder()
+                .id(1L)
+                .chatRoomEntityId(ChatRoomEntityId.of(100L))
+                .level(1)
+                .content("test content")
+                .senderType(SenderType.USER)
+                .createdAt(now)
+                .modifiedAt(now)
+                .deletedAt(null)
+                .build();
+
+        // when
+        ChatMessage domain = chatMessageMapper.toDomain(entity);
+
+        // then
+        assertThat(domain.getId()).isEqualTo(entity.getId());
+        assertThat(domain.getChatRoomId().getValue()).isEqualTo(entity.getChatRoomEntityId().getValue());
+        assertThat(domain.getLevel()).isEqualTo(entity.getLevel());
+        assertThat(domain.getContent()).isEqualTo(entity.getContent());
+        assertThat(domain.getSenderType()).isEqualTo(entity.getSenderType());
+        assertThat(domain.getCreatedAt()).isEqualTo(entity.getCreatedAt());
+        assertThat(domain.getModifiedAt()).isEqualTo(entity.getModifiedAt());
+        assertThat(domain.getDeletedAt()).isEqualTo(entity.getDeletedAt());
+    }
+
+    @Test
+    @DisplayName("ChatMessage Domain을 ChatMessageEntity로 변환한다")
+    void toEntity() {
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        ChatMessage domain = ChatMessage.from(
+                1L,
+                ChatRoomId.of(100L),
+                1,
+                "test content",
+                SenderType.USER,
+                now,
+                now,
+                null
+        );
+
+        // when
+        ChatMessageEntity entity = chatMessageMapper.toEntity(domain);
+
+        // then
+        assertThat(entity.getId()).isEqualTo(domain.getId());
+        assertThat(entity.getChatRoomEntityId().getValue()).isEqualTo(domain.getChatRoomId().getValue());
+        assertThat(entity.getLevel()).isEqualTo(domain.getLevel());
+        assertThat(entity.getContent()).isEqualTo(domain.getContent());
+        assertThat(entity.getSenderType()).isEqualTo(domain.getSenderType());
+        assertThat(entity.getCreatedAt()).isEqualTo(domain.getCreatedAt());
+        assertThat(entity.getModifiedAt()).isEqualTo(domain.getModifiedAt());
+        assertThat(entity.getDeletedAt()).isEqualTo(domain.getDeletedAt());
+    }
+
+    @Test
+    @DisplayName("null ChatMessage Domain을 Entity로 변환하면 null을 반환한다")
+    void toEntity_withNullDomain_shouldReturnNull() {
+        // when
+        ChatMessageEntity entity = chatMessageMapper.toEntity(null);
+
+        // then
+        assertThat(entity).isNull();
+    }
+}

--- a/src/test/java/makeus/cmc/malmo/mapper/ChatMessageSummaryMapperTest.java
+++ b/src/test/java/makeus/cmc/malmo/mapper/ChatMessageSummaryMapperTest.java
@@ -1,0 +1,100 @@
+package makeus.cmc.malmo.mapper;
+
+import makeus.cmc.malmo.adaptor.out.persistence.entity.chat.ChatMessageSummaryEntity;
+import makeus.cmc.malmo.adaptor.out.persistence.entity.value.ChatRoomEntityId;
+import makeus.cmc.malmo.adaptor.out.persistence.mapper.ChatMessageSummaryMapper;
+import makeus.cmc.malmo.domain.model.chat.ChatMessageSummary;
+import makeus.cmc.malmo.domain.value.id.ChatRoomId;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ChatMessageSummaryMapper 테스트")
+class ChatMessageSummaryMapperTest {
+
+    @InjectMocks
+    private ChatMessageSummaryMapper chatMessageSummaryMapper;
+
+    @Test
+    @DisplayName("ChatMessageSummaryEntity를 ChatMessageSummary Domain으로 변환한다")
+    void toDomain() {
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        ChatMessageSummaryEntity entity = ChatMessageSummaryEntity.builder()
+                .id(1L)
+                .chatRoomEntityId(ChatRoomEntityId.of(100L))
+                .content("summary content")
+                .level(1)
+                .createdAt(now)
+                .modifiedAt(now)
+                .deletedAt(null)
+                .build();
+
+        // when
+        ChatMessageSummary domain = chatMessageSummaryMapper.toDomain(entity);
+
+        // then
+        assertThat(domain.getId()).isEqualTo(entity.getId());
+        assertThat(domain.getChatRoomId().getValue()).isEqualTo(entity.getChatRoomEntityId().getValue());
+        assertThat(domain.getContent()).isEqualTo(entity.getContent());
+        assertThat(domain.getLevel()).isEqualTo(entity.getLevel());
+        assertThat(domain.getCreatedAt()).isEqualTo(entity.getCreatedAt());
+        assertThat(domain.getModifiedAt()).isEqualTo(entity.getModifiedAt());
+        assertThat(domain.getDeletedAt()).isEqualTo(entity.getDeletedAt());
+    }
+
+    @Test
+    @DisplayName("ChatMessageSummary Domain을 ChatMessageSummaryEntity로 변환한다")
+    void toEntity() {
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        ChatMessageSummary domain = ChatMessageSummary.from(
+                1L,
+                ChatRoomId.of(100L),
+                "summary content",
+                1,
+                now,
+                now,
+                null
+        );
+
+        // when
+        ChatMessageSummaryEntity entity = chatMessageSummaryMapper.toEntity(domain);
+
+        // then
+        assertThat(entity.getId()).isEqualTo(domain.getId());
+        assertThat(entity.getChatRoomEntityId().getValue()).isEqualTo(domain.getChatRoomId().getValue());
+        assertThat(entity.getContent()).isEqualTo(domain.getContent());
+        assertThat(entity.getLevel()).isEqualTo(domain.getLevel());
+        assertThat(entity.getCreatedAt()).isEqualTo(domain.getCreatedAt());
+        assertThat(entity.getModifiedAt()).isEqualTo(domain.getModifiedAt());
+        assertThat(entity.getDeletedAt()).isEqualTo(domain.getDeletedAt());
+    }
+
+    @Test
+    @DisplayName("null Entity를 Domain으로 변환하면 null을 반환한다")
+    void toDomain_withNullEntity_shouldReturnNull() {
+        // when
+        ChatMessageSummary domain = chatMessageSummaryMapper.toDomain(null);
+
+        // then
+        assertThat(domain).isNull();
+    }
+
+    @Test
+    @DisplayName("null Domain을 Entity로 변환하면 null을 반환한다")
+    void toEntity_withNullDomain_shouldReturnNull() {
+        // when
+        ChatMessageSummaryEntity entity = chatMessageSummaryMapper.toEntity(null);
+
+        // then
+        assertThat(entity).isNull();
+    }
+}

--- a/src/test/java/makeus/cmc/malmo/mapper/ChatRoomMapperTest.java
+++ b/src/test/java/makeus/cmc/malmo/mapper/ChatRoomMapperTest.java
@@ -1,0 +1,107 @@
+package makeus.cmc.malmo.mapper;
+
+import makeus.cmc.malmo.adaptor.out.persistence.entity.chat.ChatRoomEntity;
+import makeus.cmc.malmo.adaptor.out.persistence.entity.value.MemberEntityId;
+import makeus.cmc.malmo.adaptor.out.persistence.mapper.ChatRoomMapper;
+import makeus.cmc.malmo.domain.model.chat.ChatRoom;
+import makeus.cmc.malmo.domain.value.id.MemberId;
+import makeus.cmc.malmo.domain.value.state.ChatRoomState;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ChatRoomMapper 테스트")
+class ChatRoomMapperTest {
+
+    @InjectMocks
+    private ChatRoomMapper chatRoomMapper;
+
+    @Test
+    @DisplayName("ChatRoomEntity를 ChatRoom Domain으로 변환한다")
+    void toDomain() {
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        ChatRoomEntity entity = ChatRoomEntity.builder()
+                .id(1L)
+                .memberEntityId(MemberEntityId.of(100L))
+                .chatRoomState(ChatRoomState.ALIVE)
+                .level(1)
+                .lastMessageSentTime(now)
+                .totalSummary("total summary")
+                .situationKeyword("situation")
+                .solutionKeyword("solution")
+                .createdAt(now)
+                .modifiedAt(now)
+                .deletedAt(null)
+                .build();
+
+        // when
+        ChatRoom domain = chatRoomMapper.toDomain(entity);
+
+        // then
+        assertThat(domain.getId()).isEqualTo(entity.getId());
+        assertThat(domain.getMemberId().getValue()).isEqualTo(entity.getMemberEntityId().getValue());
+        assertThat(domain.getChatRoomState()).isEqualTo(entity.getChatRoomState());
+        assertThat(domain.getLevel()).isEqualTo(entity.getLevel());
+        assertThat(domain.getLastMessageSentTime()).isEqualTo(entity.getLastMessageSentTime());
+        assertThat(domain.getTotalSummary()).isEqualTo(entity.getTotalSummary());
+        assertThat(domain.getSituationKeyword()).isEqualTo(entity.getSituationKeyword());
+        assertThat(domain.getSolutionKeyword()).isEqualTo(entity.getSolutionKeyword());
+        assertThat(domain.getCreatedAt()).isEqualTo(entity.getCreatedAt());
+        assertThat(domain.getModifiedAt()).isEqualTo(entity.getModifiedAt());
+        assertThat(domain.getDeletedAt()).isEqualTo(entity.getDeletedAt());
+    }
+
+    @Test
+    @DisplayName("ChatRoom Domain을 ChatRoomEntity로 변환한다")
+    void toEntity() {
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        ChatRoom domain = ChatRoom.from(
+                1L,
+                MemberId.of(100L),
+                ChatRoomState.ALIVE,
+                1,
+                now,
+                "total summary",
+                "situation",
+                "solution",
+                now,
+                now,
+                null
+        );
+
+        // when
+        ChatRoomEntity entity = chatRoomMapper.toEntity(domain);
+
+        // then
+        assertThat(entity.getId()).isEqualTo(domain.getId());
+        assertThat(entity.getMemberEntityId().getValue()).isEqualTo(domain.getMemberId().getValue());
+        assertThat(entity.getChatRoomState()).isEqualTo(domain.getChatRoomState());
+        assertThat(entity.getLevel()).isEqualTo(domain.getLevel());
+        assertThat(entity.getLastMessageSentTime()).isEqualTo(domain.getLastMessageSentTime());
+        assertThat(entity.getTotalSummary()).isEqualTo(domain.getTotalSummary());
+        assertThat(entity.getSituationKeyword()).isEqualTo(domain.getSituationKeyword());
+        assertThat(entity.getSolutionKeyword()).isEqualTo(domain.getSolutionKeyword());
+        assertThat(entity.getCreatedAt()).isEqualTo(domain.getCreatedAt());
+        assertThat(entity.getModifiedAt()).isEqualTo(domain.getModifiedAt());
+        assertThat(entity.getDeletedAt()).isEqualTo(domain.getDeletedAt());
+    }
+
+    @Test
+    @DisplayName("null Domain을 Entity로 변환하면 null을 반환한다")
+    void toEntity_withNullDomain_shouldReturnNull() {
+        // when
+        ChatRoomEntity entity = chatRoomMapper.toEntity(null);
+
+        // then
+        assertThat(entity).isNull();
+    }
+}

--- a/src/test/java/makeus/cmc/malmo/mapper/CoupleAggregateMapperTest.java
+++ b/src/test/java/makeus/cmc/malmo/mapper/CoupleAggregateMapperTest.java
@@ -43,47 +43,40 @@ class CoupleAggregateMapperTest {
 
             // then
             assertThat(result).isNotNull();
-            assertThat(result.getId()).isEqualTo(1L);
-            assertThat(result.getStartLoveDate()).isEqualTo(LocalDate.of(2024, 1, 1));
-            assertThat(result.getCoupleState()).isEqualTo(CoupleState.ALIVE);
-            assertThat(result.getFirstMemberId().getValue()).isEqualTo(100L);
-            assertThat(result.getSecondMemberId().getValue()).isEqualTo(200L);
-            assertThat(result.getCreatedAt()).isNotNull();
-            assertThat(result.getModifiedAt()).isNotNull();
-            assertThat(result.getDeletedAt()).isNull();
+            assertThat(result.getId()).isEqualTo(entity.getId());
+            assertThat(result.getStartLoveDate()).isEqualTo(entity.getStartLoveDate());
+            assertThat(result.getCoupleState()).isEqualTo(entity.getCoupleState());
+            assertThat(result.getFirstMemberId().getValue()).isEqualTo(entity.getFirstMemberId().getValue());
+            assertThat(result.getSecondMemberId().getValue()).isEqualTo(entity.getSecondMemberId().getValue());
+            assertThat(result.getCreatedAt()).isEqualTo(entity.getCreatedAt());
+            assertThat(result.getModifiedAt()).isEqualTo(entity.getModifiedAt());
+            assertThat(result.getDeletedAt()).isEqualTo(entity.getDeletedAt());
 
-            // CoupleMemberSnapshot 검증
+            // First CoupleMemberSnapshot 검증
             CoupleMemberSnapshot firstSnapshot = result.getFirstMemberSnapshot();
-            assertThat(firstSnapshot.getNickname()).isEqualTo("first");
-            assertThat(firstSnapshot.getLoveTypeCategory()).isEqualTo(LoveTypeCategory.STABLE_TYPE);
-            assertThat(firstSnapshot.getAnxietyRate()).isEqualTo(10);
-            assertThat(firstSnapshot.getAvoidanceRate()).isEqualTo(20);
+            CoupleMemberSnapshotEntity firstSnapshotEntity = entity.getFirstMemberSnapshot();
+            assertThat(firstSnapshot.getNickname()).isEqualTo(firstSnapshotEntity.getNickname());
+            assertThat(firstSnapshot.getLoveTypeCategory()).isEqualTo(firstSnapshotEntity.getLoveTypeCategory());
+            assertThat(firstSnapshot.getAnxietyRate()).isEqualTo(firstSnapshotEntity.getAnxietyRate());
+            assertThat(firstSnapshot.getAvoidanceRate()).isEqualTo(firstSnapshotEntity.getAvoidanceRate());
 
+            // Second CoupleMemberSnapshot 검증
             CoupleMemberSnapshot secondSnapshot = result.getSecondMemberSnapshot();
-            assertThat(secondSnapshot.getNickname()).isEqualTo("second");
+            CoupleMemberSnapshotEntity secondSnapshotEntity = entity.getSecondMemberSnapshot();
+            assertThat(secondSnapshot.getNickname()).isEqualTo(secondSnapshotEntity.getNickname());
+            assertThat(secondSnapshot.getLoveTypeCategory()).isEqualTo(secondSnapshotEntity.getLoveTypeCategory());
+            assertThat(secondSnapshot.getAnxietyRate()).isEqualTo(secondSnapshotEntity.getAnxietyRate());
+            assertThat(secondSnapshot.getAvoidanceRate()).isEqualTo(secondSnapshotEntity.getAvoidanceRate());
         }
 
         @Test
-        @DisplayName("다양한 CoupleState를 가진 Entity를 변환한다")
-        void givenDifferentCoupleStates_whenToDomain_thenReturnsCorrectStates() {
-            // given & when & then
-            CoupleEntity deletedEntity = createEntityWithState(CoupleState.DELETED);
-            Couple deletedResult = coupleAggregateMapper.toDomain(deletedEntity);
-            assertThat(deletedResult.getCoupleState()).isEqualTo(CoupleState.DELETED);
-        }
-
-        @Test
-        @DisplayName("null CoupleState를 가진 Entity를 변환한다")
-        void givenEntityWithNullCoupleState_whenToDomain_thenReturnsCoupleWithNullState() {
-            // given
-            CoupleEntity entity = createEntityWithNullState();
-
+        @DisplayName("null Entity를 변환하면 null을 반환한다")
+        void givenNullEntity_whenToDomain_thenReturnsNull() {
             // when
-            Couple result = coupleAggregateMapper.toDomain(entity);
+            Couple result = coupleAggregateMapper.toDomain(null);
 
             // then
-            assertThat(result).isNotNull();
-            assertThat(result.getCoupleState()).isNull();
+            assertThat(result).isNull();
         }
     }
 
@@ -102,47 +95,40 @@ class CoupleAggregateMapperTest {
 
             // then
             assertThat(result).isNotNull();
-            assertThat(result.getId()).isEqualTo(1L);
-            assertThat(result.getStartLoveDate()).isEqualTo(LocalDate.of(2024, 1, 1));
-            assertThat(result.getCoupleState()).isEqualTo(CoupleState.ALIVE);
-            assertThat(result.getFirstMemberId().getValue()).isEqualTo(100L);
-            assertThat(result.getSecondMemberId().getValue()).isEqualTo(200L);
-            assertThat(result.getCreatedAt()).isNotNull();
-            assertThat(result.getModifiedAt()).isNotNull();
-            assertThat(result.getDeletedAt()).isNull();
+            assertThat(result.getId()).isEqualTo(domain.getId());
+            assertThat(result.getStartLoveDate()).isEqualTo(domain.getStartLoveDate());
+            assertThat(result.getCoupleState()).isEqualTo(domain.getCoupleState());
+            assertThat(result.getFirstMemberId().getValue()).isEqualTo(domain.getFirstMemberId().getValue());
+            assertThat(result.getSecondMemberId().getValue()).isEqualTo(domain.getSecondMemberId().getValue());
+            assertThat(result.getCreatedAt()).isEqualTo(domain.getCreatedAt());
+            assertThat(result.getModifiedAt()).isEqualTo(domain.getModifiedAt());
+            assertThat(result.getDeletedAt()).isEqualTo(domain.getDeletedAt());
 
-            // CoupleMemberSnapshotEntity 검증
+            // First CoupleMemberSnapshotEntity 검증
             CoupleMemberSnapshotEntity firstSnapshotEntity = result.getFirstMemberSnapshot();
-            assertThat(firstSnapshotEntity.getNickname()).isEqualTo("first");
-            assertThat(firstSnapshotEntity.getLoveTypeCategory()).isEqualTo(LoveTypeCategory.STABLE_TYPE);
-            assertThat(firstSnapshotEntity.getAnxietyRate()).isEqualTo(10);
-            assertThat(firstSnapshotEntity.getAvoidanceRate()).isEqualTo(20);
+            CoupleMemberSnapshot firstSnapshot = domain.getFirstMemberSnapshot();
+            assertThat(firstSnapshotEntity.getNickname()).isEqualTo(firstSnapshot.getNickname());
+            assertThat(firstSnapshotEntity.getLoveTypeCategory()).isEqualTo(firstSnapshot.getLoveTypeCategory());
+            assertThat(firstSnapshotEntity.getAnxietyRate()).isEqualTo(firstSnapshot.getAnxietyRate());
+            assertThat(firstSnapshotEntity.getAvoidanceRate()).isEqualTo(firstSnapshot.getAvoidanceRate());
 
+            // Second CoupleMemberSnapshotEntity 검증
             CoupleMemberSnapshotEntity secondSnapshotEntity = result.getSecondMemberSnapshot();
-            assertThat(secondSnapshotEntity.getNickname()).isEqualTo("second");
+            CoupleMemberSnapshot secondSnapshot = domain.getSecondMemberSnapshot();
+            assertThat(secondSnapshotEntity.getNickname()).isEqualTo(secondSnapshot.getNickname());
+            assertThat(secondSnapshotEntity.getLoveTypeCategory()).isEqualTo(secondSnapshot.getLoveTypeCategory());
+            assertThat(secondSnapshotEntity.getAnxietyRate()).isEqualTo(secondSnapshot.getAnxietyRate());
+            assertThat(secondSnapshotEntity.getAvoidanceRate()).isEqualTo(secondSnapshot.getAvoidanceRate());
         }
 
         @Test
-        @DisplayName("다양한 CoupleState를 가진 Couple을 변환한다")
-        void givenDifferentCoupleStates_whenToEntity_thenReturnsCorrectStates() {
-            // given & when & then
-            Couple deletedCouple = createCoupleWithState(CoupleState.DELETED);
-            CoupleEntity deletedResult = coupleAggregateMapper.toEntity(deletedCouple);
-            assertThat(deletedResult.getCoupleState()).isEqualTo(CoupleState.DELETED);
-        }
-
-        @Test
-        @DisplayName("null CoupleState를 가진 Couple을 변환한다")
-        void givenCoupleWithNullState_whenToEntity_thenReturnsEntityWithNullState() {
-            // given
-            Couple domain = createCoupleWithNullState();
-
+        @DisplayName("null Domain을 변환하면 null을 반환한다")
+        void givenNullDomain_whenToEntity_thenReturnsNull() {
             // when
-            CoupleEntity result = coupleAggregateMapper.toEntity(domain);
+            CoupleEntity result = coupleAggregateMapper.toEntity(null);
 
             // then
-            assertThat(result).isNotNull();
-            assertThat(result.getCoupleState()).isNull();
+            assertThat(result).isNull();
         }
     }
 
@@ -154,36 +140,20 @@ class CoupleAggregateMapperTest {
                 .coupleState(CoupleState.ALIVE)
                 .firstMemberId(MemberEntityId.of(100L))
                 .secondMemberId(MemberEntityId.of(200L))
-                .firstMemberSnapshot(createSnapshotEntity("first"))
-                .secondMemberSnapshot(createSnapshotEntity("second"))
+                .firstMemberSnapshot(createSnapshotEntity("first", LoveTypeCategory.STABLE_TYPE, 10, 20))
+                .secondMemberSnapshot(createSnapshotEntity("second", LoveTypeCategory.ANXIETY_TYPE, 30, 40))
                 .createdAt(LocalDateTime.now())
                 .modifiedAt(LocalDateTime.now())
                 .deletedAt(null)
                 .build();
     }
 
-    private CoupleEntity createEntityWithState(CoupleState state) {
-        return CoupleEntity.builder()
-                .id(1L)
-                .startLoveDate(LocalDate.of(2024, 1, 1))
-                .coupleState(state)
-                .build();
-    }
-
-    private CoupleEntity createEntityWithNullState() {
-        return CoupleEntity.builder()
-                .id(1L)
-                .startLoveDate(LocalDate.of(2024, 1, 1))
-                .coupleState(null)
-                .build();
-    }
-
-    private CoupleMemberSnapshotEntity createSnapshotEntity(String nickname) {
+    private CoupleMemberSnapshotEntity createSnapshotEntity(String nickname, LoveTypeCategory category, int anxiety, int avoidance) {
         return CoupleMemberSnapshotEntity.builder()
                 .nickname(nickname)
-                .loveTypeCategory(LoveTypeCategory.STABLE_TYPE)
-                .anxietyRate(10)
-                .avoidanceRate(20)
+                .loveTypeCategory(category)
+                .anxietyRate(anxiety)
+                .avoidanceRate(avoidance)
                 .build();
     }
 
@@ -195,41 +165,20 @@ class CoupleAggregateMapperTest {
                 MemberId.of(100L),
                 MemberId.of(200L),
                 CoupleState.ALIVE,
-                createSnapshot("first"),
-                createSnapshot("second"),
+                createSnapshot("first", LoveTypeCategory.STABLE_TYPE, 20f, 10f),
+                createSnapshot("second", LoveTypeCategory.ANXIETY_TYPE, 40f, 30f),
                 LocalDateTime.now(),
                 LocalDateTime.now(),
                 null
         );
     }
 
-    private Couple createCoupleWithState(CoupleState state) {
-        return Couple.from(
-                1L,
-                LocalDate.of(2024, 1, 1),
-                MemberId.of(100L),
-                MemberId.of(200L),
-                state,
-                createSnapshot("first"),
-                createSnapshot("second"),
-                LocalDateTime.now(),
-                LocalDateTime.now(),
-                null
-        );
-    }
-
-    private Couple createCoupleWithNullState() {
-        return Couple.from(
-                1L,
-                LocalDate.of(2024, 1, 1),
-                MemberId.of(100L),
-                MemberId.of(200L),
-                null,
-                createSnapshot("first"),
-                createSnapshot("second"),
-                LocalDateTime.now(),
-                LocalDateTime.now(),
-                null
+    private CoupleMemberSnapshot createSnapshot(String nickname, LoveTypeCategory category, float avoidanceRate, float anxietyRate) {
+        return CoupleMemberSnapshot.from(
+                nickname,
+                category,
+                avoidanceRate,
+                anxietyRate
         );
     }
 

--- a/src/test/java/makeus/cmc/malmo/mapper/CoupleQuestionMapperTest.java
+++ b/src/test/java/makeus/cmc/malmo/mapper/CoupleQuestionMapperTest.java
@@ -1,0 +1,172 @@
+package makeus.cmc.malmo.mapper;
+
+import makeus.cmc.malmo.adaptor.out.persistence.entity.question.CoupleQuestionEntity;
+import makeus.cmc.malmo.adaptor.out.persistence.entity.question.QuestionEntity;
+import makeus.cmc.malmo.adaptor.out.persistence.entity.question.TempCoupleQuestionEntity;
+import makeus.cmc.malmo.adaptor.out.persistence.entity.value.CoupleEntityId;
+import makeus.cmc.malmo.adaptor.out.persistence.entity.value.MemberEntityId;
+import makeus.cmc.malmo.adaptor.out.persistence.mapper.CoupleQuestionMapper;
+import makeus.cmc.malmo.adaptor.out.persistence.mapper.QuestionMapper;
+import makeus.cmc.malmo.domain.model.question.CoupleQuestion;
+import makeus.cmc.malmo.domain.model.question.Question;
+import makeus.cmc.malmo.domain.model.question.TempCoupleQuestion;
+import makeus.cmc.malmo.domain.value.id.CoupleId;
+import makeus.cmc.malmo.domain.value.id.MemberId;
+import makeus.cmc.malmo.domain.value.state.CoupleQuestionState;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("CoupleQuestionMapper 테스트")
+class CoupleQuestionMapperTest {
+
+    @InjectMocks
+    private CoupleQuestionMapper coupleQuestionMapper;
+
+    @Mock
+    private QuestionMapper questionMapper;
+
+    private Question questionDomain;
+    private QuestionEntity questionEntity;
+
+    @BeforeEach
+    void setUp() {
+        LocalDateTime now = LocalDateTime.now();
+        questionDomain = Question.from(1L, "t", "c", 1, now, now, null);
+        questionEntity = QuestionEntity.builder().id(1L).title("t").content("c").level(1).createdAt(now).modifiedAt(now).deletedAt(null).build();
+    }
+
+    @Nested
+    @DisplayName("CoupleQuestion <-> CoupleQuestionEntity")
+    class CoupleQuestionTest {
+        @Test
+        @DisplayName("Entity를 Domain으로 변환한다")
+        void toDomain() {
+            // given
+            LocalDateTime now = LocalDateTime.now();
+            CoupleQuestionEntity entity = CoupleQuestionEntity.builder()
+                    .id(1L)
+                    .question(questionEntity)
+                    .coupleEntityId(CoupleEntityId.of(100L))
+                    .coupleQuestionState(CoupleQuestionState.COMPLETED)
+                    .bothAnsweredAt(now)
+                    .createdAt(now)
+                    .modifiedAt(now)
+                    .deletedAt(null)
+                    .build();
+
+            when(questionMapper.toDomain(any(QuestionEntity.class))).thenReturn(questionDomain);
+
+            // when
+            CoupleQuestion domain = coupleQuestionMapper.toDomain(entity);
+
+            // then
+            assertThat(domain.getId()).isEqualTo(entity.getId());
+            assertThat(domain.getQuestion()).isEqualTo(questionDomain);
+            assertThat(domain.getCoupleId().getValue()).isEqualTo(entity.getCoupleEntityId().getValue());
+            assertThat(domain.getCoupleQuestionState()).isEqualTo(entity.getCoupleQuestionState());
+            assertThat(domain.getBothAnsweredAt()).isEqualTo(entity.getBothAnsweredAt());
+            assertThat(domain.getCreatedAt()).isEqualTo(entity.getCreatedAt());
+            assertThat(domain.getModifiedAt()).isEqualTo(entity.getModifiedAt());
+            assertThat(domain.getDeletedAt()).isEqualTo(entity.getDeletedAt());
+        }
+
+        @Test
+        @DisplayName("Domain을 Entity로 변환한다")
+        void toEntity() {
+            // given
+            LocalDateTime now = LocalDateTime.now();
+            CoupleQuestion domain = CoupleQuestion.from(1L, questionDomain, CoupleId.of(100L), CoupleQuestionState.COMPLETED, now, now, now, null);
+
+            when(questionMapper.toEntity(any(Question.class))).thenReturn(questionEntity);
+
+            // when
+            CoupleQuestionEntity entity = coupleQuestionMapper.toEntity(domain);
+
+            // then
+            assertThat(entity.getId()).isEqualTo(domain.getId());
+            assertThat(entity.getQuestion()).isEqualTo(questionEntity);
+            assertThat(entity.getCoupleEntityId().getValue()).isEqualTo(domain.getCoupleId().getValue());
+            assertThat(entity.getCoupleQuestionState()).isEqualTo(domain.getCoupleQuestionState());
+            assertThat(entity.getBothAnsweredAt()).isEqualTo(domain.getBothAnsweredAt());
+            assertThat(entity.getCreatedAt()).isEqualTo(domain.getCreatedAt());
+            assertThat(entity.getModifiedAt()).isEqualTo(domain.getModifiedAt());
+            assertThat(entity.getDeletedAt()).isEqualTo(domain.getDeletedAt());
+        }
+    }
+
+    @Nested
+    @DisplayName("TempCoupleQuestion <-> TempCoupleQuestionEntity")
+    class TempCoupleQuestionTest {
+        @Test
+        @DisplayName("Entity를 Domain으로 변환한다")
+        void toDomain() {
+            // given
+            LocalDateTime now = LocalDateTime.now();
+            TempCoupleQuestionEntity entity = TempCoupleQuestionEntity.builder()
+                    .id(1L)
+                    .question(questionEntity)
+                    .memberId(MemberEntityId.of(200L))
+                    .answer("answer")
+                    .coupleQuestionState(CoupleQuestionState.ALIVE)
+                    .answeredAt(now)
+                    .createdAt(now)
+                    .modifiedAt(now)
+                    .deletedAt(null)
+                    .build();
+
+            when(questionMapper.toDomain(any(QuestionEntity.class))).thenReturn(questionDomain);
+
+
+            // when
+            TempCoupleQuestion domain = coupleQuestionMapper.toDomain(entity);
+
+            // then
+            assertThat(domain.getId()).isEqualTo(entity.getId());
+            assertThat(domain.getQuestion()).isEqualTo(questionDomain);
+            assertThat(domain.getMemberId().getValue()).isEqualTo(entity.getMemberId().getValue());
+            assertThat(domain.getAnswer()).isEqualTo(entity.getAnswer());
+            assertThat(domain.getCoupleQuestionState()).isEqualTo(entity.getCoupleQuestionState());
+            assertThat(domain.getAnsweredAt()).isEqualTo(entity.getAnsweredAt());
+            assertThat(domain.getCreatedAt()).isEqualTo(entity.getCreatedAt());
+            assertThat(domain.getModifiedAt()).isEqualTo(entity.getModifiedAt());
+            assertThat(domain.getDeletedAt()).isEqualTo(entity.getDeletedAt());
+        }
+
+        @Test
+        @DisplayName("Domain을 Entity로 변환한다")
+        void toEntity() {
+            // given
+            LocalDateTime now = LocalDateTime.now();
+            TempCoupleQuestion domain = TempCoupleQuestion.from(1L, questionDomain, MemberId.of(200L), "answer", CoupleQuestionState.ALIVE, now, now, now, null);
+
+            when(questionMapper.toEntity(any(Question.class))).thenReturn(questionEntity);
+
+            // when
+            TempCoupleQuestionEntity entity = coupleQuestionMapper.toEntity(domain);
+
+            // then
+            assertThat(entity.getId()).isEqualTo(domain.getId());
+            assertThat(entity.getQuestion()).isEqualTo(questionEntity);
+            assertThat(entity.getMemberId().getValue()).isEqualTo(domain.getMemberId().getValue());
+            assertThat(entity.getAnswer()).isEqualTo(domain.getAnswer());
+            assertThat(entity.getCoupleQuestionState()).isEqualTo(domain.getCoupleQuestionState());
+            assertThat(entity.getAnsweredAt()).isEqualTo(domain.getAnsweredAt());
+            assertThat(entity.getCreatedAt()).isEqualTo(domain.getCreatedAt());
+            assertThat(entity.getModifiedAt()).isEqualTo(domain.getModifiedAt());
+            assertThat(entity.getDeletedAt()).isEqualTo(domain.getDeletedAt());
+        }
+    }
+}

--- a/src/test/java/makeus/cmc/malmo/mapper/MemberAnswerMapperTest.java
+++ b/src/test/java/makeus/cmc/malmo/mapper/MemberAnswerMapperTest.java
@@ -1,0 +1,87 @@
+package makeus.cmc.malmo.mapper;
+
+import makeus.cmc.malmo.adaptor.out.persistence.entity.question.MemberAnswerEntity;
+import makeus.cmc.malmo.adaptor.out.persistence.entity.value.CoupleQuestionEntityId;
+import makeus.cmc.malmo.adaptor.out.persistence.entity.value.MemberEntityId;
+import makeus.cmc.malmo.adaptor.out.persistence.mapper.MemberAnswerMapper;
+import makeus.cmc.malmo.domain.model.question.MemberAnswer;
+import makeus.cmc.malmo.domain.value.id.CoupleQuestionId;
+import makeus.cmc.malmo.domain.value.id.MemberId;
+import makeus.cmc.malmo.domain.value.state.MemberAnswerState;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("MemberAnswerMapper 테스트")
+class MemberAnswerMapperTest {
+
+    @InjectMocks
+    private MemberAnswerMapper memberAnswerMapper;
+
+    @Test
+    @DisplayName("Entity를 Domain으로 변환한다")
+    void toDomain() {
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        MemberAnswerEntity entity = MemberAnswerEntity.builder()
+                .id(1L)
+                .coupleQuestionEntityId(CoupleQuestionEntityId.of(100L))
+                .memberEntityId(MemberEntityId.of(200L))
+                .answer("answer")
+                .memberAnswerState(MemberAnswerState.ALIVE)
+                .createdAt(now)
+                .modifiedAt(now)
+                .deletedAt(null)
+                .build();
+
+        // when
+        MemberAnswer domain = memberAnswerMapper.toDomain(entity);
+
+        // then
+        assertThat(domain.getId()).isEqualTo(entity.getId());
+        assertThat(domain.getCoupleQuestionId().getValue()).isEqualTo(entity.getCoupleQuestionEntityId().getValue());
+        assertThat(domain.getMemberId().getValue()).isEqualTo(entity.getMemberEntityId().getValue());
+        assertThat(domain.getAnswer()).isEqualTo(entity.getAnswer());
+        assertThat(domain.getMemberAnswerState()).isEqualTo(entity.getMemberAnswerState());
+        assertThat(domain.getCreatedAt()).isEqualTo(entity.getCreatedAt());
+        assertThat(domain.getModifiedAt()).isEqualTo(entity.getModifiedAt());
+        assertThat(domain.getDeletedAt()).isEqualTo(entity.getDeletedAt());
+    }
+
+    @Test
+    @DisplayName("Domain을 Entity로 변환한다")
+    void toEntity() {
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        MemberAnswer domain = MemberAnswer.from(
+                1L,
+                CoupleQuestionId.of(100L),
+                MemberId.of(200L),
+                "answer",
+                MemberAnswerState.ALIVE,
+                now,
+                now,
+                null
+        );
+
+        // when
+        MemberAnswerEntity entity = memberAnswerMapper.toEntity(domain);
+
+        // then
+        assertThat(entity.getId()).isEqualTo(domain.getId());
+        assertThat(entity.getCoupleQuestionEntityId().getValue()).isEqualTo(domain.getCoupleQuestionId().getValue());
+        assertThat(entity.getMemberEntityId().getValue()).isEqualTo(domain.getMemberId().getValue());
+        assertThat(entity.getAnswer()).isEqualTo(domain.getAnswer());
+        assertThat(entity.getMemberAnswerState()).isEqualTo(domain.getMemberAnswerState());
+        assertThat(entity.getCreatedAt()).isEqualTo(domain.getCreatedAt());
+        assertThat(entity.getModifiedAt()).isEqualTo(domain.getModifiedAt());
+        assertThat(entity.getDeletedAt()).isEqualTo(domain.getDeletedAt());
+    }
+}

--- a/src/test/java/makeus/cmc/malmo/mapper/MemberMapperTest.java
+++ b/src/test/java/makeus/cmc/malmo/mapper/MemberMapperTest.java
@@ -1,6 +1,8 @@
 package makeus.cmc.malmo.mapper;
 
 import makeus.cmc.malmo.adaptor.out.persistence.entity.member.MemberEntity;
+import makeus.cmc.malmo.adaptor.out.persistence.entity.value.CoupleEntityId;
+import makeus.cmc.malmo.adaptor.out.persistence.entity.value.InviteCodeEntityValue;
 import makeus.cmc.malmo.adaptor.out.persistence.mapper.MemberMapper;
 import makeus.cmc.malmo.domain.model.member.Member;
 import makeus.cmc.malmo.domain.value.id.CoupleId;
@@ -34,85 +36,15 @@ class MemberMapperTest {
 
         @Test
         @DisplayName("모든 필드가 있는 MemberEntity를 Member로 변환한다")
-        void givenCompleteEntity_whenToDomain_thenReturnsCompleteMember() {
+        void toDomain() {
             // given
             MemberEntity entity = createCompleteEntity();
 
             // when
-            Member result = memberMapper.toDomain(entity);
+            Member domain = memberMapper.toDomain(entity);
 
             // then
-            assertThat(result).isNotNull();
-            assertThat(result.getId()).isEqualTo(1L);
-            assertThat(result.getProvider()).isEqualTo(Provider.KAKAO);
-            assertThat(result.getProviderId()).isEqualTo("provider123");
-            assertThat(result.getMemberRole()).isEqualTo(MemberRole.MEMBER);
-            assertThat(result.getMemberState()).isEqualTo(MemberState.ALIVE);
-            assertThat(result.isAlarmOn()).isTrue();
-            assertThat(result.getFirebaseToken()).isEqualTo("firebase_token");
-            assertThat(result.getRefreshToken()).isEqualTo("refresh_token");
-            assertThat(result.getLoveTypeCategory()).isEqualTo(LoveTypeCategory.STABLE_TYPE);
-            assertThat(result.getAvoidanceRate()).isEqualTo(0.5f);
-            assertThat(result.getAnxietyRate()).isEqualTo(0.3f);
-            assertThat(result.getNickname()).isEqualTo("testuser");
-            assertThat(result.getEmail()).isEqualTo("test@example.com");
-        }
-
-        @Test
-        @DisplayName("null 값이 포함된 MemberEntity를 Member로 변환한다")
-        void givenEntityWithNulls_whenToDomain_thenReturnsValidMember() {
-            // given
-            MemberEntity entity = createEntityWithNulls();
-
-            // when
-            Member result = memberMapper.toDomain(entity);
-
-            // then
-            assertThat(result).isNotNull();
-            assertThat(result.getProvider()).isNull();
-            assertThat(result.getMemberRole()).isNull();
-            assertThat(result.getMemberState()).isNull();
-            assertThat(result.getLoveTypeCategory()).isNull();
-        }
-
-        @Test
-        @DisplayName("Apple Provider를 가진 Entity를 변환한다")
-        void givenAppleProvider_whenToDomain_thenReturnsAppleProvider() {
-            // given
-            MemberEntity entity = createEntityWithProvider(Provider.APPLE);
-
-            // when
-            Member result = memberMapper.toDomain(entity);
-
-            // then
-            assertThat(result.getProvider()).isEqualTo(Provider.APPLE);
-        }
-
-        @Test
-        @DisplayName("ADMIN Role을 가진 Entity를 변환한다")
-        void givenAdminRole_whenToDomain_thenReturnsAdminRole() {
-            // given
-            MemberEntity entity = createEntityWithRole(MemberRole.ADMIN);
-
-            // when
-            Member result = memberMapper.toDomain(entity);
-
-            // then
-            assertThat(result.getMemberRole()).isEqualTo(MemberRole.ADMIN);
-        }
-
-        @Test
-        @DisplayName("다양한 MemberState를 가진 Entity를 변환한다")
-        void givenDifferentStates_whenToDomain_thenReturnsCorrectStates() {
-            // given
-            // when & then
-            MemberEntity beforeOnboardingEntity = createEntityWithState(MemberState.BEFORE_ONBOARDING);
-            Member beforeOnboardingResult = memberMapper.toDomain(beforeOnboardingEntity);
-            assertThat(beforeOnboardingResult.getMemberState()).isEqualTo(MemberState.BEFORE_ONBOARDING);
-
-            MemberEntity deletedEntity = createEntityWithState(MemberState.DELETED);
-            Member deletedResult = memberMapper.toDomain(deletedEntity);
-            assertThat(deletedResult.getMemberState()).isEqualTo(MemberState.DELETED);
+            assertMember(domain, entity);
         }
     }
 
@@ -122,91 +54,66 @@ class MemberMapperTest {
 
         @Test
         @DisplayName("모든 필드가 있는 Member를 MemberEntity로 변환한다")
-        void givenCompleteMember_whenToEntity_thenReturnsCompleteEntity() {
+        void toEntity() {
             // given
             Member domain = createCompleteMember();
 
             // when
-            MemberEntity result = memberMapper.toEntity(domain);
+            MemberEntity entity = memberMapper.toEntity(domain);
 
             // then
-            assertThat(result).isNotNull();
-            assertThat(result.getId()).isEqualTo(1L);
-            assertThat(result.getProvider()).isEqualTo(Provider.KAKAO);
-            assertThat(result.getProviderId()).isEqualTo("provider123");
-            assertThat(result.getMemberRole()).isEqualTo(MemberRole.MEMBER);
-            assertThat(result.getMemberState()).isEqualTo(MemberState.ALIVE);
-            assertThat(result.isAlarmOn()).isTrue();
-            assertThat(result.getFirebaseToken()).isEqualTo("firebase_token");
-            assertThat(result.getRefreshToken()).isEqualTo("refresh_token");
-            assertThat(result.getLoveTypeCategory()).isEqualTo(LoveTypeCategory.STABLE_TYPE);
-            assertThat(result.getAvoidanceRate()).isEqualTo(0.5f);
-            assertThat(result.getAnxietyRate()).isEqualTo(0.3f);
-            assertThat(result.getNickname()).isEqualTo("testuser");
-            assertThat(result.getEmail()).isEqualTo("test@example.com");
-        }
-
-        @Test
-        @DisplayName("null 값이 포함된 Member를 MemberEntity로 변환한다")
-        void givenMemberWithNulls_whenToEntity_thenReturnsValidEntity() {
-            // given
-            Member domain = createMemberWithNulls();
-
-            // when
-            MemberEntity result = memberMapper.toEntity(domain);
-
-            // then
-            assertThat(result).isNotNull();
-            assertThat(result.getId()).isNull();
-            assertThat(result.getLoveTypeCategory()).isNull();
-            assertThat(result.getProvider()).isNull();
-            assertThat(result.getMemberRole()).isNull();
-            assertThat(result.getMemberState()).isNull();
-        }
-
-        @Test
-        @DisplayName("Apple Provider를 가진 Member를 변환한다")
-        void givenAppleProvider_whenToEntity_thenReturnsAppleProvider() {
-            // given
-            Member domain = createMemberWithProvider(Provider.APPLE);
-
-            // when
-            MemberEntity result = memberMapper.toEntity(domain);
-
-            // then
-            assertThat(result.getProvider()).isEqualTo(Provider.APPLE);
-        }
-
-        @Test
-        @DisplayName("ADMIN Role을 가진 Member를 변환한다")
-        void givenAdminRole_whenToEntity_thenReturnsAdminRole() {
-            // given
-            Member domain = createMemberWithRole(MemberRole.ADMIN);
-
-            // when
-            MemberEntity result = memberMapper.toEntity(domain);
-
-            // then
-            assertThat(result.getMemberRole()).isEqualTo(MemberRole.ADMIN);
-        }
-
-        @Test
-        @DisplayName("다양한 MemberState를 가진 Member를 변환한다")
-        void givenDifferentStates_whenToEntity_thenReturnsCorrectStates() {
-            // given
-            // when & then
-            Member beforeOnboardingMember = createMemberWithState(MemberState.BEFORE_ONBOARDING);
-            MemberEntity beforeOnboardingResult = memberMapper.toEntity(beforeOnboardingMember);
-            assertThat(beforeOnboardingResult.getMemberState()).isEqualTo(MemberState.BEFORE_ONBOARDING);
-
-            Member deletedMember = createMemberWithState(MemberState.DELETED);
-            MemberEntity deletedResult = memberMapper.toEntity(deletedMember);
-            assertThat(deletedResult.getMemberState()).isEqualTo(MemberState.DELETED);
+            assertMemberEntity(entity, domain);
         }
     }
 
-    // Test data creation methods
+    private void assertMember(Member domain, MemberEntity entity) {
+        assertThat(domain.getId()).isEqualTo(entity.getId());
+        assertThat(domain.getProvider()).isEqualTo(entity.getProvider());
+        assertThat(domain.getProviderId()).isEqualTo(entity.getProviderId());
+        assertThat(domain.getMemberRole()).isEqualTo(entity.getMemberRole());
+        assertThat(domain.getMemberState()).isEqualTo(entity.getMemberState());
+        assertThat(domain.isAlarmOn()).isEqualTo(entity.isAlarmOn());
+        assertThat(domain.getFirebaseToken()).isEqualTo(entity.getFirebaseToken());
+        assertThat(domain.getRefreshToken()).isEqualTo(entity.getRefreshToken());
+        assertThat(domain.getLoveTypeCategory()).isEqualTo(entity.getLoveTypeCategory());
+        assertThat(domain.getAvoidanceRate()).isEqualTo(entity.getAvoidanceRate());
+        assertThat(domain.getAnxietyRate()).isEqualTo(entity.getAnxietyRate());
+        assertThat(domain.getNickname()).isEqualTo(entity.getNickname());
+        assertThat(domain.getEmail()).isEqualTo(entity.getEmail());
+        assertThat(domain.getInviteCode().getValue()).isEqualTo(entity.getInviteCodeEntityValue().getValue());
+        assertThat(domain.getStartLoveDate()).isEqualTo(entity.getStartLoveDate());
+        assertThat(domain.getOauthToken()).isEqualTo(entity.getOauthToken());
+        assertThat(domain.getCoupleId().getValue()).isEqualTo(entity.getCoupleEntityId().getValue());
+        assertThat(domain.getCreatedAt()).isEqualTo(entity.getCreatedAt());
+        assertThat(domain.getModifiedAt()).isEqualTo(entity.getModifiedAt());
+        assertThat(domain.getDeletedAt()).isEqualTo(entity.getDeletedAt());
+    }
+
+    private void assertMemberEntity(MemberEntity entity, Member domain) {
+        assertThat(entity.getId()).isEqualTo(domain.getId());
+        assertThat(entity.getProvider()).isEqualTo(domain.getProvider());
+        assertThat(entity.getProviderId()).isEqualTo(domain.getProviderId());
+        assertThat(entity.getMemberRole()).isEqualTo(domain.getMemberRole());
+        assertThat(entity.getMemberState()).isEqualTo(domain.getMemberState());
+        assertThat(entity.isAlarmOn()).isEqualTo(domain.isAlarmOn());
+        assertThat(entity.getFirebaseToken()).isEqualTo(domain.getFirebaseToken());
+        assertThat(entity.getRefreshToken()).isEqualTo(domain.getRefreshToken());
+        assertThat(entity.getLoveTypeCategory()).isEqualTo(domain.getLoveTypeCategory());
+        assertThat(entity.getAvoidanceRate()).isEqualTo(domain.getAvoidanceRate());
+        assertThat(entity.getAnxietyRate()).isEqualTo(domain.getAnxietyRate());
+        assertThat(entity.getNickname()).isEqualTo(domain.getNickname());
+        assertThat(entity.getEmail()).isEqualTo(domain.getEmail());
+        assertThat(entity.getInviteCodeEntityValue().getValue()).isEqualTo(domain.getInviteCode().getValue());
+        assertThat(entity.getStartLoveDate()).isEqualTo(domain.getStartLoveDate());
+        assertThat(entity.getOauthToken()).isEqualTo(domain.getOauthToken());
+        assertThat(entity.getCoupleEntityId().getValue()).isEqualTo(domain.getCoupleId().getValue());
+        assertThat(entity.getCreatedAt()).isEqualTo(domain.getCreatedAt());
+        assertThat(entity.getModifiedAt()).isEqualTo(domain.getModifiedAt());
+        assertThat(entity.getDeletedAt()).isEqualTo(domain.getDeletedAt());
+    }
+
     private MemberEntity createCompleteEntity() {
+        LocalDateTime now = LocalDateTime.now();
         return MemberEntity.builder()
                 .id(1L)
                 .provider(Provider.KAKAO)
@@ -221,43 +128,18 @@ class MemberMapperTest {
                 .anxietyRate(0.3f)
                 .nickname("testuser")
                 .email("test@example.com")
-                .createdAt(LocalDateTime.now())
-                .modifiedAt(LocalDateTime.now())
-                .build();
-    }
-
-    private MemberEntity createEntityWithNulls() {
-        return MemberEntity.builder()
-                .id(1L)
-                .provider(null)
-                .memberRole(null)
-                .memberState(null)
-                .loveTypeCategory(null)
-                .build();
-    }
-
-    private MemberEntity createEntityWithProvider(Provider provider) {
-        return MemberEntity.builder()
-                .id(1L)
-                .provider(provider)
-                .build();
-    }
-
-    private MemberEntity createEntityWithRole(MemberRole role) {
-        return MemberEntity.builder()
-                .id(1L)
-                .memberRole(role)
-                .build();
-    }
-
-    private MemberEntity createEntityWithState(MemberState state) {
-        return MemberEntity.builder()
-                .id(1L)
-                .memberState(state)
+                .inviteCodeEntityValue(InviteCodeEntityValue.of("invite_code"))
+                .startLoveDate(LocalDate.now())
+                .oauthToken("oauth_token")
+                .coupleEntityId(CoupleEntityId.of(100L))
+                .createdAt(now)
+                .modifiedAt(now)
+                .deletedAt(null)
                 .build();
     }
 
     private Member createCompleteMember() {
+        LocalDateTime now = LocalDateTime.now();
         return Member.from(
                 1L,
                 Provider.KAKAO,
@@ -272,37 +154,13 @@ class MemberMapperTest {
                 0.3f,
                 "testuser",
                 "test@example.com",
-                null, // InviteCodeValue
+                InviteCodeValue.of("invite_code"),
                 LocalDate.now(),
-                null, // oauthToken
-                null, // CoupleId
-                LocalDateTime.now(),
-                LocalDateTime.now(),
+                "oauth_token",
+                CoupleId.of(100L),
+                now,
+                now,
                 null
-        );
-    }
-
-    private Member createMemberWithNulls() {
-        return Member.createMember(
-                null, null, null, null, null, null, null
-        );
-    }
-
-    private Member createMemberWithProvider(Provider provider) {
-        return Member.createMember(
-                provider, "provider123", MemberRole.MEMBER, MemberState.ALIVE, "", null, null
-        );
-    }
-
-    private Member createMemberWithRole(MemberRole role) {
-        return Member.createMember(
-                Provider.KAKAO, "provider123", role, MemberState.ALIVE, "", null, null
-        );
-    }
-
-    private Member createMemberWithState(MemberState state) {
-        return Member.createMember(
-                Provider.KAKAO, "provider123", MemberRole.MEMBER, state, "", null, null
         );
     }
 }

--- a/src/test/java/makeus/cmc/malmo/mapper/MemberMemoryMapperTest.java
+++ b/src/test/java/makeus/cmc/malmo/mapper/MemberMemoryMapperTest.java
@@ -1,0 +1,107 @@
+package makeus.cmc.malmo.mapper;
+
+import makeus.cmc.malmo.adaptor.out.persistence.entity.member.MemberMemoryEntity;
+import makeus.cmc.malmo.adaptor.out.persistence.entity.value.CoupleEntityId;
+import makeus.cmc.malmo.adaptor.out.persistence.entity.value.MemberEntityId;
+import makeus.cmc.malmo.adaptor.out.persistence.mapper.MemberMemoryMapper;
+import makeus.cmc.malmo.domain.model.member.MemberMemory;
+import makeus.cmc.malmo.domain.value.id.CoupleId;
+import makeus.cmc.malmo.domain.value.id.MemberId;
+import makeus.cmc.malmo.domain.value.state.MemberMemoryState;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("MemberMemoryMapper 테스트")
+class MemberMemoryMapperTest {
+
+    @InjectMocks
+    private MemberMemoryMapper memberMemoryMapper;
+
+    @Test
+    @DisplayName("Entity를 Domain으로 변환한다")
+    void toDomain() {
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        MemberMemoryEntity entity = MemberMemoryEntity.builder()
+                .id(1L)
+                .coupleEntityId(CoupleEntityId.of(100L))
+                .memberEntityId(MemberEntityId.of(200L))
+                .content("memory content")
+                .memberMemoryState(MemberMemoryState.ALIVE)
+                .createdAt(now)
+                .modifiedAt(now)
+                .deletedAt(null)
+                .build();
+
+        // when
+        MemberMemory domain = memberMemoryMapper.toDomain(entity);
+
+        // then
+        assertThat(domain.getId()).isEqualTo(entity.getId());
+        assertThat(domain.getCoupleId().getValue()).isEqualTo(entity.getCoupleEntityId().getValue());
+        assertThat(domain.getMemberId().getValue()).isEqualTo(entity.getMemberEntityId().getValue());
+        assertThat(domain.getContent()).isEqualTo(entity.getContent());
+        assertThat(domain.getMemberMemoryState()).isEqualTo(entity.getMemberMemoryState());
+        assertThat(domain.getCreatedAt()).isEqualTo(entity.getCreatedAt());
+        assertThat(domain.getModifiedAt()).isEqualTo(entity.getModifiedAt());
+        assertThat(domain.getDeletedAt()).isEqualTo(entity.getDeletedAt());
+    }
+
+    @Test
+    @DisplayName("Domain을 Entity로 변환한다")
+    void toEntity() {
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        MemberMemory domain = MemberMemory.from(
+                1L,
+                CoupleId.of(100L),
+                MemberId.of(200L),
+                "memory content",
+                MemberMemoryState.ALIVE,
+                now,
+                now,
+                null
+        );
+
+        // when
+        MemberMemoryEntity entity = memberMemoryMapper.toEntity(domain);
+
+        // then
+        assertThat(entity.getId()).isEqualTo(domain.getId());
+        assertThat(entity.getCoupleEntityId().getValue()).isEqualTo(domain.getCoupleId().getValue());
+        assertThat(entity.getMemberEntityId().getValue()).isEqualTo(domain.getMemberId().getValue());
+        assertThat(entity.getContent()).isEqualTo(domain.getContent());
+        assertThat(entity.getMemberMemoryState()).isEqualTo(domain.getMemberMemoryState());
+        assertThat(entity.getCreatedAt()).isEqualTo(domain.getCreatedAt());
+        assertThat(entity.getModifiedAt()).isEqualTo(domain.getModifiedAt());
+        assertThat(entity.getDeletedAt()).isEqualTo(domain.getDeletedAt());
+    }
+
+    @Test
+    @DisplayName("null Entity를 Domain으로 변환하면 null을 반환한다")
+    void toDomain_withNullEntity() {
+        // when
+        MemberMemory domain = memberMemoryMapper.toDomain(null);
+
+        // then
+        assertThat(domain).isNull();
+    }
+
+    @Test
+    @DisplayName("null Domain을 Entity로 변환하면 null을 반환한다")
+    void toEntity_withNullDomain() {
+        // when
+        MemberMemoryEntity entity = memberMemoryMapper.toEntity(null);
+
+        // then
+        assertThat(entity).isNull();
+    }
+}

--- a/src/test/java/makeus/cmc/malmo/mapper/MemberNotificationMapperTest.java
+++ b/src/test/java/makeus/cmc/malmo/mapper/MemberNotificationMapperTest.java
@@ -1,0 +1,89 @@
+package makeus.cmc.malmo.mapper;
+
+import makeus.cmc.malmo.adaptor.out.persistence.entity.notification.MemberNotificationEntity;
+import makeus.cmc.malmo.adaptor.out.persistence.entity.value.MemberEntityId;
+import makeus.cmc.malmo.adaptor.out.persistence.mapper.MemberNotificationMapper;
+import makeus.cmc.malmo.domain.model.notification.MemberNotification;
+import makeus.cmc.malmo.domain.value.id.MemberId;
+import makeus.cmc.malmo.domain.value.state.NotificationState;
+import makeus.cmc.malmo.domain.value.type.NotificationType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("MemberNotificationMapper 테스트")
+class MemberNotificationMapperTest {
+
+    @InjectMocks
+    private MemberNotificationMapper memberNotificationMapper;
+
+    @Test
+    @DisplayName("Entity를 Domain으로 변환한다")
+    void toDomain() {
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        Map<String, Object> payload = Map.of("key", "value");
+        MemberNotificationEntity entity = MemberNotificationEntity.builder()
+                .id(1L)
+                .memberId(MemberEntityId.of(100L))
+                .type(NotificationType.COUPLE_DISCONNECTED)
+                .state(NotificationState.PENDING)
+                .payload(payload)
+                .createdAt(now)
+                .modifiedAt(now)
+                .deletedAt(null)
+                .build();
+
+        // when
+        MemberNotification domain = memberNotificationMapper.toDomain(entity);
+
+        // then
+        assertThat(domain.getId()).isEqualTo(entity.getId());
+        assertThat(domain.getMemberId().getValue()).isEqualTo(entity.getMemberId().getValue());
+        assertThat(domain.getType()).isEqualTo(entity.getType());
+        assertThat(domain.getState()).isEqualTo(entity.getState());
+        assertThat(domain.getPayload()).isEqualTo(entity.getPayload());
+        assertThat(domain.getCreatedAt()).isEqualTo(entity.getCreatedAt());
+        assertThat(domain.getModifiedAt()).isEqualTo(entity.getModifiedAt());
+        assertThat(domain.getDeletedAt()).isEqualTo(entity.getDeletedAt());
+    }
+
+    @Test
+    @DisplayName("Domain을 Entity로 변환한다")
+    void toEntity() {
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        Map<String, Object> payload = Map.of("key", "value");
+        MemberNotification domain = MemberNotification.from(
+                1L,
+                MemberId.of(100L),
+                NotificationType.COUPLE_DISCONNECTED,
+                NotificationState.PENDING,
+                payload,
+                now,
+                now,
+                null
+        );
+
+        // when
+        MemberNotificationEntity entity = memberNotificationMapper.toEntity(domain);
+
+        // then
+        assertThat(entity.getId()).isEqualTo(domain.getId());
+        assertThat(entity.getMemberId().getValue()).isEqualTo(domain.getMemberId().getValue());
+        assertThat(entity.getType()).isEqualTo(domain.getType());
+        assertThat(entity.getState()).isEqualTo(domain.getState());
+        assertThat(entity.getPayload()).isEqualTo(domain.getPayload());
+        assertThat(entity.getCreatedAt()).isEqualTo(domain.getCreatedAt());
+        assertThat(entity.getModifiedAt()).isEqualTo(domain.getModifiedAt());
+        assertThat(entity.getDeletedAt()).isEqualTo(domain.getDeletedAt());
+    }
+}

--- a/src/test/java/makeus/cmc/malmo/mapper/MemberTermsAgreementMapperTest.java
+++ b/src/test/java/makeus/cmc/malmo/mapper/MemberTermsAgreementMapperTest.java
@@ -1,8 +1,6 @@
 package makeus.cmc.malmo.mapper;
 
-import makeus.cmc.malmo.adaptor.out.persistence.entity.member.MemberEntity;
 import makeus.cmc.malmo.adaptor.out.persistence.entity.terms.MemberTermsAgreementEntity;
-import makeus.cmc.malmo.adaptor.out.persistence.entity.terms.TermsEntity;
 import makeus.cmc.malmo.adaptor.out.persistence.entity.value.MemberEntityId;
 import makeus.cmc.malmo.adaptor.out.persistence.entity.value.TermsEntityId;
 import makeus.cmc.malmo.adaptor.out.persistence.mapper.MemberTermsAgreementMapper;
@@ -10,7 +8,6 @@ import makeus.cmc.malmo.domain.model.terms.MemberTermsAgreement;
 import makeus.cmc.malmo.domain.value.id.MemberId;
 import makeus.cmc.malmo.domain.value.id.TermsId;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -27,224 +24,67 @@ class MemberTermsAgreementMapperTest {
     @InjectMocks
     private MemberTermsAgreementMapper memberTermsAgreementMapper;
 
-    @Nested
-    @DisplayName("Entity를 Domain으로 변환할 때")
-    class ToDomainTest {
+    @Test
+    @DisplayName("Entity를 Domain으로 변환한다")
+    void toDomain() {
+        // given
+        MemberTermsAgreementEntity entity = createCompleteEntity();
 
-        @Test
-        @DisplayName("모든 필드가 있는 MemberTermsAgreementEntity를 MemberTermsAgreement로 변환한다")
-        void givenCompleteEntity_whenToDomain_thenReturnsCompleteMemberTermsAgreement() {
-            // given
-            MemberTermsAgreementEntity entity = createCompleteEntity();
+        // when
+        MemberTermsAgreement domain = memberTermsAgreementMapper.toDomain(entity);
 
-            // when
-            MemberTermsAgreement result = memberTermsAgreementMapper.toDomain(entity);
-
-            // then
-            assertThat(result).isNotNull();
-            assertThat(result.getId()).isEqualTo(1L);
-            assertThat(result.getMemberId().getValue()).isEqualTo(100L);
-            assertThat(result.getTermsId().getValue()).isEqualTo(200L);
-            assertThat(result.isAgreed()).isTrue();
-            assertThat(result.getCreatedAt()).isNotNull();
-            assertThat(result.getModifiedAt()).isNotNull();
-            assertThat(result.getDeletedAt()).isNull();
-        }
-
-        @Test
-        @DisplayName("동의하지 않은 약관의 Entity를 변환한다")
-        void givenDisagreedEntity_whenToDomain_thenReturnsDisagreedMemberTermsAgreement() {
-            // given
-            MemberTermsAgreementEntity entity = createDisagreedEntity();
-
-            // when
-            MemberTermsAgreement result = memberTermsAgreementMapper.toDomain(entity);
-
-            // then
-            assertThat(result).isNotNull();
-            assertThat(result.isAgreed()).isFalse();
-        }
-
-        @Test
-        @DisplayName("삭제된 약관 동의 Entity를 변환한다")
-        void givenDeletedEntity_whenToDomain_thenReturnsDeletedMemberTermsAgreement() {
-            // given
-            LocalDateTime deletedAt = LocalDateTime.now();
-            MemberTermsAgreementEntity entity = createDeletedEntity(deletedAt);
-
-            // when
-            MemberTermsAgreement result = memberTermsAgreementMapper.toDomain(entity);
-
-            // then
-            assertThat(result).isNotNull();
-            assertThat(result.getDeletedAt()).isEqualTo(deletedAt);
-        }
+        // then
+        assertThat(domain.getId()).isEqualTo(entity.getId());
+        assertThat(domain.getMemberId().getValue()).isEqualTo(entity.getMemberEntityId().getValue());
+        assertThat(domain.getTermsId().getValue()).isEqualTo(entity.getTermsEntityId().getValue());
+        assertThat(domain.isAgreed()).isEqualTo(entity.isAgreed());
+        assertThat(domain.getCreatedAt()).isEqualTo(entity.getCreatedAt());
+        assertThat(domain.getModifiedAt()).isEqualTo(entity.getModifiedAt());
+        assertThat(domain.getDeletedAt()).isEqualTo(entity.getDeletedAt());
     }
 
-    @Nested
-    @DisplayName("Domain을 Entity로 변환할 때")
-    class ToEntityTest {
+    @Test
+    @DisplayName("Domain을 Entity로 변환한다")
+    void toEntity() {
+        // given
+        MemberTermsAgreement domain = createCompleteDomain();
 
-        @Test
-        @DisplayName("모든 필드가 있는 MemberTermsAgreement를 MemberTermsAgreementEntity로 변환한다")
-        void givenCompleteMemberTermsAgreement_whenToEntity_thenReturnsCompleteEntity() {
-            // given
-            MemberTermsAgreement domain = createCompleteMemberTermsAgreement();
+        // when
+        MemberTermsAgreementEntity entity = memberTermsAgreementMapper.toEntity(domain);
 
-            // when
-            MemberTermsAgreementEntity result = memberTermsAgreementMapper.toEntity(domain);
-
-            // then
-            assertThat(result).isNotNull();
-            assertThat(result.getId()).isEqualTo(1L);
-            assertThat(result.getMemberEntityId().getValue()).isEqualTo(100L);
-            assertThat(result.getTermsEntityId().getValue()).isEqualTo(200L);
-            assertThat(result.isAgreed()).isTrue();
-            assertThat(result.getCreatedAt()).isNotNull();
-            assertThat(result.getModifiedAt()).isNotNull();
-            assertThat(result.getDeletedAt()).isNull();
-        }
-
-        @Test
-        @DisplayName("동의하지 않은 MemberTermsAgreement를 변환한다")
-        void givenDisagreedMemberTermsAgreement_whenToEntity_thenReturnsDisagreedEntity() {
-            // given
-            MemberTermsAgreement domain = createDisagreedMemberTermsAgreement();
-
-            // when
-            MemberTermsAgreementEntity result = memberTermsAgreementMapper.toEntity(domain);
-
-            // then
-            assertThat(result).isNotNull();
-            assertThat(result.isAgreed()).isFalse();
-        }
-
-        @Test
-        @DisplayName("삭제된 MemberTermsAgreement를 변환한다")
-        void givenDeletedMemberTermsAgreement_whenToEntity_thenReturnsDeletedEntity() {
-            // given
-            LocalDateTime deletedAt = LocalDateTime.now();
-            MemberTermsAgreement domain = createDeletedMemberTermsAgreement(deletedAt);
-
-            // when
-            MemberTermsAgreementEntity result = memberTermsAgreementMapper.toEntity(domain);
-
-            // then
-            assertThat(result).isNotNull();
-            assertThat(result.getDeletedAt()).isEqualTo(deletedAt);
-        }
-
-        @Test
-        @DisplayName("null ID를 가진 MemberTermsAgreement를 변환한다")
-        void givenMemberTermsAgreementWithNullId_whenToEntity_thenReturnsEntityWithNullId() {
-            // given
-            MemberTermsAgreement domain = createMemberTermsAgreementWithNullId();
-
-            // when
-            MemberTermsAgreementEntity result = memberTermsAgreementMapper.toEntity(domain);
-
-            // then
-            assertThat(result).isNotNull();
-            assertThat(result.getId()).isNull();
-            assertThat(result.getMemberEntityId().getValue()).isEqualTo(100L);
-            assertThat(result.getTermsEntityId().getValue()).isEqualTo(200L);
-        }
+        // then
+        assertThat(entity.getId()).isEqualTo(domain.getId());
+        assertThat(entity.getMemberEntityId().getValue()).isEqualTo(domain.getMemberId().getValue());
+        assertThat(entity.getTermsEntityId().getValue()).isEqualTo(domain.getTermsId().getValue());
+        assertThat(entity.isAgreed()).isEqualTo(domain.isAgreed());
+        assertThat(entity.getCreatedAt()).isEqualTo(domain.getCreatedAt());
+        assertThat(entity.getModifiedAt()).isEqualTo(domain.getModifiedAt());
+        assertThat(entity.getDeletedAt()).isEqualTo(domain.getDeletedAt());
     }
 
-    // Test data creation methods
     private MemberTermsAgreementEntity createCompleteEntity() {
-        MemberEntity member = createMemberEntity();
-        TermsEntity terms = createTermsEntity();
-        
+        LocalDateTime now = LocalDateTime.now();
         return MemberTermsAgreementEntity.builder()
                 .id(1L)
-                .memberEntityId(MemberEntityId.of(member.getId()))
-                .termsEntityId(TermsEntityId.of(terms.getId()))
+                .memberEntityId(MemberEntityId.of(100L))
+                .termsEntityId(TermsEntityId.of(200L))
                 .agreed(true)
-                .createdAt(LocalDateTime.now())
-                .modifiedAt(LocalDateTime.now())
+                .createdAt(now)
+                .modifiedAt(now)
                 .deletedAt(null)
                 .build();
     }
 
-    private MemberTermsAgreementEntity createDisagreedEntity() {
-        MemberEntity member = createMemberEntity();
-        TermsEntity terms = createTermsEntity();
-        
-        return MemberTermsAgreementEntity.builder()
-                .id(1L)
-                .memberEntityId(MemberEntityId.of(member.getId()))
-                .termsEntityId(TermsEntityId.of(terms.getId()))
-                .agreed(false)
-                .build();
-    }
-
-    private MemberTermsAgreementEntity createDeletedEntity(LocalDateTime deletedAt) {
-        MemberEntity member = createMemberEntity();
-        TermsEntity terms = createTermsEntity();
-        
-        return MemberTermsAgreementEntity.builder()
-                .id(1L)
-                .memberEntityId(MemberEntityId.of(member.getId()))
-                .termsEntityId(TermsEntityId.of(terms.getId()))
-                .agreed(true)
-                .deletedAt(deletedAt)
-                .build();
-    }
-
-    private MemberEntity createMemberEntity() {
-        return MemberEntity.builder()
-                .id(100L)
-                .build();
-    }
-
-    private TermsEntity createTermsEntity() {
-        return TermsEntity.builder()
-                .id(200L)
-                .build();
-    }
-
-    private MemberTermsAgreement createCompleteMemberTermsAgreement() {
+    private MemberTermsAgreement createCompleteDomain() {
+        LocalDateTime now = LocalDateTime.now();
         return MemberTermsAgreement.from(
                 1L,
                 MemberId.of(100L),
                 TermsId.of(200L),
                 true,
-                LocalDateTime.now(),
-                LocalDateTime.now(),
+                now,
+                now,
                 null
-        );
-    }
-
-    private MemberTermsAgreement createDisagreedMemberTermsAgreement() {
-        return MemberTermsAgreement.from(
-                1L,
-                MemberId.of(100L),
-                TermsId.of(200L),
-                false,
-                LocalDateTime.now(),
-                LocalDateTime.now(),
-                null
-        );
-    }
-
-    private MemberTermsAgreement createDeletedMemberTermsAgreement(LocalDateTime deletedAt) {
-        return MemberTermsAgreement.from(
-                1L,
-                MemberId.of(100L),
-                TermsId.of(200L),
-                true,
-                LocalDateTime.now(),
-                LocalDateTime.now(),
-                deletedAt
-        );
-    }
-
-    private MemberTermsAgreement createMemberTermsAgreementWithNullId() {
-        return MemberTermsAgreement.signTerms(
-                MemberId.of(100L),
-                TermsId.of(200L),
-                true
         );
     }
 }

--- a/src/test/java/makeus/cmc/malmo/mapper/PromptMapperTest.java
+++ b/src/test/java/makeus/cmc/malmo/mapper/PromptMapperTest.java
@@ -1,0 +1,94 @@
+package makeus.cmc.malmo.mapper;
+
+import makeus.cmc.malmo.adaptor.out.persistence.entity.chat.PromptEntity;
+import makeus.cmc.malmo.adaptor.out.persistence.mapper.PromptMapper;
+import makeus.cmc.malmo.domain.model.chat.Prompt;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("PromptMapper 테스트")
+class PromptMapperTest {
+
+    @InjectMocks
+    private PromptMapper promptMapper;
+
+    @Test
+    @DisplayName("Entity를 Domain으로 변환한다")
+    void toDomain() {
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        PromptEntity entity = PromptEntity.builder()
+                .id(1L)
+                .level(1)
+                .content("prompt content")
+                .createdAt(now)
+                .modifiedAt(now)
+                .deletedAt(null)
+                .build();
+
+        // when
+        Prompt domain = promptMapper.toDomain(entity);
+
+        // then
+        assertThat(domain.getId()).isEqualTo(entity.getId());
+        assertThat(domain.getLevel()).isEqualTo(entity.getLevel());
+        assertThat(domain.getContent()).isEqualTo(entity.getContent());
+        assertThat(domain.getCreatedAt()).isEqualTo(entity.getCreatedAt());
+        assertThat(domain.getModifiedAt()).isEqualTo(entity.getModifiedAt());
+        assertThat(domain.getDeletedAt()).isEqualTo(entity.getDeletedAt());
+    }
+
+    @Test
+    @DisplayName("Domain을 Entity로 변환한다")
+    void toEntity() {
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        Prompt domain = Prompt.from(
+                1L,
+                1,
+                "prompt content",
+                now,
+                now,
+                null
+        );
+
+        // when
+        PromptEntity entity = promptMapper.toEntity(domain);
+
+        // then
+        assertThat(entity.getId()).isEqualTo(domain.getId());
+        assertThat(entity.getLevel()).isEqualTo(domain.getLevel());
+        assertThat(entity.getContent()).isEqualTo(domain.getContent());
+        assertThat(entity.getCreatedAt()).isEqualTo(domain.getCreatedAt());
+        assertThat(entity.getModifiedAt()).isEqualTo(domain.getModifiedAt());
+        assertThat(entity.getDeletedAt()).isEqualTo(domain.getDeletedAt());
+    }
+
+    @Test
+    @DisplayName("null Entity를 Domain으로 변환하면 null을 반환한다")
+    void toDomain_withNullEntity() {
+        // when
+        Prompt domain = promptMapper.toDomain(null);
+
+        // then
+        assertThat(domain).isNull();
+    }
+
+    @Test
+    @DisplayName("null Domain을 Entity로 변환하면 null을 반환한다")
+    void toEntity_withNullDomain() {
+        // when
+        PromptEntity entity = promptMapper.toEntity(null);
+
+        // then
+        assertThat(entity).isNull();
+    }
+}

--- a/src/test/java/makeus/cmc/malmo/mapper/QuestionMapperTest.java
+++ b/src/test/java/makeus/cmc/malmo/mapper/QuestionMapperTest.java
@@ -1,0 +1,98 @@
+package makeus.cmc.malmo.mapper;
+
+import makeus.cmc.malmo.adaptor.out.persistence.entity.question.QuestionEntity;
+import makeus.cmc.malmo.adaptor.out.persistence.mapper.QuestionMapper;
+import makeus.cmc.malmo.domain.model.question.Question;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("QuestionMapper 테스트")
+class QuestionMapperTest {
+
+    @InjectMocks
+    private QuestionMapper questionMapper;
+
+    @Test
+    @DisplayName("Entity를 Domain으로 변환한다")
+    void toDomain() {
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        QuestionEntity entity = QuestionEntity.builder()
+                .id(1L)
+                .title("title")
+                .content("content")
+                .level(1)
+                .createdAt(now)
+                .modifiedAt(now)
+                .deletedAt(null)
+                .build();
+
+        // when
+        Question domain = questionMapper.toDomain(entity);
+
+        // then
+        assertThat(domain.getId()).isEqualTo(entity.getId());
+        assertThat(domain.getTitle()).isEqualTo(entity.getTitle());
+        assertThat(domain.getContent()).isEqualTo(entity.getContent());
+        assertThat(domain.getLevel()).isEqualTo(entity.getLevel());
+        assertThat(domain.getCreatedAt()).isEqualTo(entity.getCreatedAt());
+        assertThat(domain.getModifiedAt()).isEqualTo(entity.getModifiedAt());
+        assertThat(domain.getDeletedAt()).isEqualTo(entity.getDeletedAt());
+    }
+
+    @Test
+    @DisplayName("Domain을 Entity로 변환한다")
+    void toEntity() {
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        Question domain = Question.from(
+                1L,
+                "title",
+                "content",
+                1,
+                now,
+                now,
+                null
+        );
+
+        // when
+        QuestionEntity entity = questionMapper.toEntity(domain);
+
+        // then
+        assertThat(entity.getId()).isEqualTo(domain.getId());
+        assertThat(entity.getTitle()).isEqualTo(domain.getTitle());
+        assertThat(entity.getContent()).isEqualTo(domain.getContent());
+        assertThat(entity.getLevel()).isEqualTo(domain.getLevel());
+        assertThat(entity.getCreatedAt()).isEqualTo(domain.getCreatedAt());
+        assertThat(entity.getModifiedAt()).isEqualTo(domain.getModifiedAt());
+        assertThat(entity.getDeletedAt()).isEqualTo(domain.getDeletedAt());
+    }
+
+    @Test
+    @DisplayName("null Entity를 Domain으로 변환하면 null을 반환한다")
+    void toDomain_withNullEntity() {
+        // when
+        Question domain = questionMapper.toDomain(null);
+
+        // then
+        assertThat(domain).isNull();
+    }
+
+    @Test
+    @DisplayName("null Domain을 Entity로 변환하면 null을 반환한다")
+    void toEntity_withNullDomain() {
+        // when
+        QuestionEntity entity = questionMapper.toEntity(null);
+
+        // then
+        assertThat(entity).isNull();
+    }
+}

--- a/src/test/java/makeus/cmc/malmo/mapper/TempLoveTypeMapperTest.java
+++ b/src/test/java/makeus/cmc/malmo/mapper/TempLoveTypeMapperTest.java
@@ -1,0 +1,99 @@
+package makeus.cmc.malmo.mapper;
+
+import makeus.cmc.malmo.adaptor.out.persistence.entity.TempLoveTypeEntity;
+import makeus.cmc.malmo.adaptor.out.persistence.mapper.TempLoveTypeMapper;
+import makeus.cmc.malmo.domain.model.love_type.TempLoveType;
+import makeus.cmc.malmo.domain.value.type.LoveTypeCategory;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("TempLoveTypeMapper 테스트")
+class TempLoveTypeMapperTest {
+
+    @InjectMocks
+    private TempLoveTypeMapper tempLoveTypeMapper;
+
+    @Test
+    @DisplayName("Entity를 Domain으로 변환한다")
+    void toDomain() {
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        TempLoveTypeEntity entity = TempLoveTypeEntity.builder()
+                .id(1L)
+                .category(LoveTypeCategory.STABLE_TYPE)
+                .avoidanceRate(10.5f)
+                .anxietyRate(20.5f)
+                .createdAt(now)
+                .modifiedAt(now)
+                .deletedAt(null)
+                .build();
+
+        // when
+        TempLoveType domain = tempLoveTypeMapper.toDomain(entity);
+
+        // then
+        assertThat(domain.getId()).isEqualTo(entity.getId());
+        assertThat(domain.getCategory()).isEqualTo(entity.getCategory());
+        assertThat(domain.getAvoidanceRate()).isEqualTo(entity.getAvoidanceRate());
+        assertThat(domain.getAnxietyRate()).isEqualTo(entity.getAnxietyRate());
+        assertThat(domain.getCreatedAt()).isEqualTo(entity.getCreatedAt());
+        assertThat(domain.getModifiedAt()).isEqualTo(entity.getModifiedAt());
+        assertThat(domain.getDeletedAt()).isEqualTo(entity.getDeletedAt());
+    }
+
+    @Test
+    @DisplayName("Domain을 Entity로 변환한다")
+    void toEntity() {
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        TempLoveType domain = TempLoveType.from(
+                1L,
+                LoveTypeCategory.STABLE_TYPE,
+                10.5f,
+                20.5f,
+                now,
+                now,
+                null
+        );
+
+        // when
+        TempLoveTypeEntity entity = tempLoveTypeMapper.toEntity(domain);
+
+        // then
+        assertThat(entity.getId()).isEqualTo(domain.getId());
+        assertThat(entity.getCategory()).isEqualTo(domain.getCategory());
+        assertThat(entity.getAvoidanceRate()).isEqualTo(domain.getAvoidanceRate());
+        assertThat(entity.getAnxietyRate()).isEqualTo(domain.getAnxietyRate());
+        assertThat(entity.getCreatedAt()).isEqualTo(domain.getCreatedAt());
+        assertThat(entity.getModifiedAt()).isEqualTo(domain.getModifiedAt());
+        assertThat(entity.getDeletedAt()).isEqualTo(domain.getDeletedAt());
+    }
+
+    @Test
+    @DisplayName("null Entity를 Domain으로 변환하면 null을 반환한다")
+    void toDomain_withNullEntity() {
+        // when
+        TempLoveType domain = tempLoveTypeMapper.toDomain(null);
+
+        // then
+        assertThat(domain).isNull();
+    }
+
+    @Test
+    @DisplayName("null Domain을 Entity로 변환하면 null을 반환한다")
+    void toEntity_withNullDomain() {
+        // when
+        TempLoveTypeEntity entity = tempLoveTypeMapper.toEntity(null);
+
+        // then
+        assertThat(entity).isNull();
+    }
+}

--- a/src/test/java/makeus/cmc/malmo/mapper/TermsMapperTest.java
+++ b/src/test/java/makeus/cmc/malmo/mapper/TermsMapperTest.java
@@ -1,8 +1,13 @@
 package makeus.cmc.malmo.mapper;
 
+import makeus.cmc.malmo.adaptor.out.persistence.entity.terms.TermsDetailsEntity;
 import makeus.cmc.malmo.adaptor.out.persistence.entity.terms.TermsEntity;
+import makeus.cmc.malmo.adaptor.out.persistence.entity.value.TermsEntityId;
 import makeus.cmc.malmo.adaptor.out.persistence.mapper.TermsMapper;
 import makeus.cmc.malmo.domain.model.terms.Terms;
+import makeus.cmc.malmo.domain.model.terms.TermsDetails;
+import makeus.cmc.malmo.domain.value.id.TermsId;
+import makeus.cmc.malmo.domain.value.state.TermsDetailsType;
 import makeus.cmc.malmo.domain.value.type.TermsType;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -23,141 +28,90 @@ class TermsMapperTest {
     private TermsMapper termsMapper;
 
     @Nested
-    @DisplayName("Entity를 Domain으로 변환할 때")
-    class ToDomainTest {
+    @DisplayName("Terms 매핑")
+    class TermsMappingTest {
 
         @Test
-        @DisplayName("모든 필드가 있는 TermsEntity를 Terms로 변환한다")
-        void givenCompleteEntity_whenToDomain_thenReturnsCompleteTerms() {
+        @DisplayName("Entity를 Domain으로 변환한다")
+        void toDomain() {
             // given
-            TermsEntity entity = createCompleteEntity();
+            TermsEntity entity = createCompleteTermsEntity();
 
             // when
-            Terms result = termsMapper.toDomain(entity);
+            Terms domain = termsMapper.toDomain(entity);
 
             // then
-            assertThat(result).isNotNull();
-            assertThat(result.getId()).isEqualTo(1L);
-            assertThat(result.getTitle()).isEqualTo("개인정보 처리방침");
-            assertThat(result.getContent()).isEqualTo("개인정보 처리방침 내용입니다.");
-            assertThat(result.getVersion()).isEqualTo(1.0f);
-            assertThat(result.isRequired()).isTrue();
-            assertThat(result.getTermsType()).isEqualTo(TermsType.PRIVACY_POLICY);
-            assertThat(result.getCreatedAt()).isNotNull();
-            assertThat(result.getModifiedAt()).isNotNull();
-            assertThat(result.getDeletedAt()).isNull();
+            assertThat(domain.getId()).isEqualTo(entity.getId());
+            assertThat(domain.getTitle()).isEqualTo(entity.getTitle());
+            assertThat(domain.getContent()).isEqualTo(entity.getContent());
+            assertThat(domain.getVersion()).isEqualTo(entity.getVersion());
+            assertThat(domain.isRequired()).isEqualTo(entity.isRequired());
+            assertThat(domain.getTermsType()).isEqualTo(entity.getTermsType());
+            assertThat(domain.getCreatedAt()).isEqualTo(entity.getCreatedAt());
+            assertThat(domain.getModifiedAt()).isEqualTo(entity.getModifiedAt());
+            assertThat(domain.getDeletedAt()).isEqualTo(entity.getDeletedAt());
         }
 
         @Test
-        @DisplayName("null TermsType을 가진 Entity를 변환한다")
-        void givenEntityWithNullTermsType_whenToDomain_thenReturnsTermsWithNullType() {
-            // given
-            TermsEntity entity = createEntityWithNullType();
-
-            // when
-            Terms result = termsMapper.toDomain(entity);
-
-            // then
-            assertThat(result).isNotNull();
-            assertThat(result.getTermsType()).isNull();
-        }
-
-        @Test
-        @DisplayName("SERVICE TermsType을 가진 Entity를 변환한다")
-        void givenServiceTermsType_whenToDomain_thenReturnsServiceType() {
-            // given
-            TermsEntity entity = createEntityWithType(TermsType.SERVICE_USAGE);
-
-            // when
-            Terms result = termsMapper.toDomain(entity);
-
-            // then
-            assertThat(result.getTermsType()).isEqualTo(TermsType.SERVICE_USAGE);
-        }
-
-        @Test
-        @DisplayName("MARKETING TermsType을 가진 Entity를 변환한다")
-        void givenMarketingTermsType_whenToDomain_thenReturnsMarketingType() {
-            // given
-            TermsEntity entity = createEntityWithType(TermsType.MARKETING);
-
-            // when
-            Terms result = termsMapper.toDomain(entity);
-
-            // then
-            assertThat(result.getTermsType()).isEqualTo(TermsType.MARKETING);
-        }
-    }
-
-    @Nested
-    @DisplayName("Domain을 Entity로 변환할 때")
-    class ToEntityTest {
-
-        @Test
-        @DisplayName("모든 필드가 있는 Terms를 TermsEntity로 변환한다")
-        void givenCompleteTerms_whenToEntity_thenReturnsCompleteEntity() {
+        @DisplayName("Domain을 Entity로 변환한다")
+        void toEntity() {
             // given
             Terms domain = createCompleteTerms();
 
             // when
-            TermsEntity result = termsMapper.toEntity(domain);
+            TermsEntity entity = termsMapper.toEntity(domain);
 
             // then
-            assertThat(result).isNotNull();
-            assertThat(result.getId()).isEqualTo(1L);
-            assertThat(result.getTitle()).isEqualTo("개인정보 처리방침");
-            assertThat(result.getContent()).isEqualTo("개인정보 처리방침 내용입니다.");
-            assertThat(result.getVersion()).isEqualTo(1.0f);
-            assertThat(result.isRequired()).isTrue();
-            assertThat(result.getTermsType()).isEqualTo(TermsType.PRIVACY_POLICY);
-            assertThat(result.getCreatedAt()).isNotNull();
-            assertThat(result.getModifiedAt()).isNotNull();
-            assertThat(result.getDeletedAt()).isNull();
-        }
-
-        @Test
-        @DisplayName("null TermsType을 가진 Terms를 변환한다")
-        void givenTermsWithNullType_whenToEntity_thenReturnsEntityWithNullType() {
-            // given
-            Terms domain = createTermsWithNullType();
-
-            // when
-            TermsEntity result = termsMapper.toEntity(domain);
-
-            // then
-            assertThat(result).isNotNull();
-            assertThat(result.getTermsType()).isNull();
-        }
-
-        @Test
-        @DisplayName("SERVICE TermsType을 가진 Terms를 변환한다")
-        void givenServiceTermsType_whenToEntity_thenReturnsServiceType() {
-            // given
-            Terms domain = createTermsWithType(TermsType.SERVICE_USAGE);
-
-            // when
-            TermsEntity result = termsMapper.toEntity(domain);
-
-            // then
-            assertThat(result.getTermsType()).isEqualTo(TermsType.SERVICE_USAGE);
-        }
-
-        @Test
-        @DisplayName("MARKETING TermsType을 가진 Terms를 변환한다")
-        void givenMarketingTermsType_whenToEntity_thenReturnsMarketingType() {
-            // given
-            Terms domain = createTermsWithType(TermsType.MARKETING);
-
-            // when
-            TermsEntity result = termsMapper.toEntity(domain);
-
-            // then
-            assertThat(result.getTermsType()).isEqualTo(TermsType.MARKETING);
+            assertThat(entity.getId()).isEqualTo(domain.getId());
+            assertThat(entity.getTitle()).isEqualTo(domain.getTitle());
+            assertThat(entity.getContent()).isEqualTo(domain.getContent());
+            assertThat(entity.getVersion()).isEqualTo(domain.getVersion());
+            assertThat(entity.isRequired()).isEqualTo(domain.isRequired());
+            assertThat(entity.getTermsType()).isEqualTo(domain.getTermsType());
+            assertThat(entity.getCreatedAt()).isEqualTo(domain.getCreatedAt());
+            assertThat(entity.getModifiedAt()).isEqualTo(domain.getModifiedAt());
+            assertThat(entity.getDeletedAt()).isEqualTo(domain.getDeletedAt());
         }
     }
 
-    // Test data creation methods
-    private TermsEntity createCompleteEntity() {
+    @Nested
+    @DisplayName("TermsDetails 매핑")
+    class TermsDetailsMappingTest {
+
+        @Test
+        @DisplayName("Entity를 Domain으로 변환한다")
+        void toDomain() {
+            // given
+            TermsDetailsEntity entity = createCompleteTermsDetailsEntity();
+
+            // when
+            TermsDetails domain = termsMapper.toDomain(entity);
+
+            // then
+            assertThat(domain.getId()).isEqualTo(entity.getId());
+            assertThat(domain.getTermsId().getValue()).isEqualTo(entity.getTermsEntityId().getValue());
+            assertThat(domain.getTermsDetailsType()).isEqualTo(entity.getTermsDetailsType());
+            assertThat(domain.getContent()).isEqualTo(entity.getContent());
+        }
+
+        @Test
+        @DisplayName("Domain을 Entity로 변환한다")
+        void toEntity() {
+            // given
+            TermsDetails domain = createCompleteTermsDetails();
+
+            // when
+            TermsDetailsEntity entity = termsMapper.toEntity(domain);
+
+            // then
+            assertThat(entity.getId()).isEqualTo(domain.getId());
+            assertThat(entity.getTermsEntityId().getValue()).isEqualTo(domain.getTermsId().getValue());
+            assertThat(entity.getTermsDetailsType()).isEqualTo(domain.getTermsDetailsType());
+            assertThat(entity.getContent()).isEqualTo(domain.getContent());
+        }
+    }
+
+    private TermsEntity createCompleteTermsEntity() {
         return TermsEntity.builder()
                 .id(1L)
                 .title("개인정보 처리방침")
@@ -168,28 +122,6 @@ class TermsMapperTest {
                 .createdAt(LocalDateTime.now())
                 .modifiedAt(LocalDateTime.now())
                 .deletedAt(null)
-                .build();
-    }
-
-    private TermsEntity createEntityWithNullType() {
-        return TermsEntity.builder()
-                .id(1L)
-                .title("약관")
-                .content("내용")
-                .version(1.0f)
-                .isRequired(true)
-                .termsType(null)
-                .build();
-    }
-
-    private TermsEntity createEntityWithType(TermsType type) {
-        return TermsEntity.builder()
-                .id(1L)
-                .title("약관")
-                .content("내용")
-                .version(1.0f)
-                .isRequired(true)
-                .termsType(type)
                 .build();
     }
 
@@ -207,31 +139,21 @@ class TermsMapperTest {
         );
     }
 
-    private Terms createTermsWithNullType() {
-        return Terms.from(
-                1L,
-                "약관",
-                "내용",
-                1.0f,
-                true,
-                null,
-                LocalDateTime.now(),
-                LocalDateTime.now(),
-                null
-        );
+    private TermsDetailsEntity createCompleteTermsDetailsEntity() {
+        return TermsDetailsEntity.builder()
+                .id(1L)
+                .termsEntityId(TermsEntityId.of(100L))
+                .termsDetailsType(TermsDetailsType.CONTENT)
+                .content("상세 내용")
+                .build();
     }
 
-    private Terms createTermsWithType(TermsType type) {
-        return Terms.from(
+    private TermsDetails createCompleteTermsDetails() {
+        return TermsDetails.from(
                 1L,
-                "약관",
-                "내용",
-                1.0f,
-                true,
-                type,
-                LocalDateTime.now(),
-                LocalDateTime.now(),
-                null
+                TermsId.of(100L),
+                TermsDetailsType.CONTENT,
+                "상세 내용"
         );
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> [MM-111 채팅 데이터 암호화](https://snu-team-fhkbojul.atlassian.net/browse/MM-111)

## 📝 작업 내용

> - AES 대칭키 암호화를 적용하여 DB 채팅 메시지 암호화 적용
> - 암호화 테스트 추가
> - 배포 브랜치를 기존 main, develop에서 release로 분리
