### PR TITLE
채팅방 강제종료 문제 해결

### DIFF
--- a/src/main/java/makeus/cmc/malmo/application/service/chat/ChatService.java
+++ b/src/main/java/makeus/cmc/malmo/application/service/chat/ChatService.java
@@ -57,11 +57,14 @@ public class ChatService implements SendChatMessageUseCase {
         // 채팅방이 초기화되지 않은 상태인 경우 초기화
         if (chatRoom.getChatRoomState() == ChatRoomState.BEFORE_INIT) {
             chatRoom.updateChatRoomStateAlive();
-            chatRoomCommandHelper.saveChatRoom(chatRoom);
         }
 
         // 현재 유저 메시지를 저장
         ChatMessage savedUserMessage = saveUserMessage(chatRoom, command.getMessage());
+
+        // 채팅방의 마지막 메시지 전송 시간 갱신
+        chatRoom.updateLastMessageSentTime();
+        chatRoomCommandHelper.saveChatRoom(chatRoom);
 
         // 채팅 응답 API 요청 스트림에 추가
         publishStreamMessagePort.publish(

--- a/src/main/java/makeus/cmc/malmo/domain/model/chat/ChatRoom.java
+++ b/src/main/java/makeus/cmc/malmo/domain/model/chat/ChatRoom.java
@@ -79,6 +79,10 @@ public class ChatRoom {
         this.solutionKeyword = solutionKeyword;
     }
 
+    public void updateLastMessageSentTime() {
+        this.lastMessageSentTime = LocalDateTime.now();
+    }
+
     public void complete() {
         this.chatRoomState = ChatRoomState.COMPLETED;
         this.totalSummary = COMPLETED_ROOM_CREATING_SUMMARY_LINE;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 과거 생성된 채팅방에 대해 채팅을 보낸 후 채팅방 재조회 시 강제 종료되는 문제 발생

## 📝 작업 내용

> 마지막 채팅 전송 시간을 갱신하는 로직 추가
